### PR TITLE
Non-standard package.conf support

### DIFF
--- a/Browse.hs
+++ b/Browse.hs
@@ -10,7 +10,7 @@ import Types
 ----------------------------------------------------------------
 
 browseModule :: Options -> String -> IO String
-browseModule opt mdlName = convert opt . format <$> browse mdlName
+browseModule opt mdlName = convert opt . format <$> browse opt mdlName
   where
     format
       | operators opt = formatOps
@@ -22,9 +22,9 @@ browseModule opt mdlName = convert opt . format <$> browse mdlName
       | otherwise = '(' : x ++ ")"
     formatOps' [] = error "formatOps'"
 
-browse :: String -> IO [String]
-browse mdlName = withGHC $ do
-    initSession0
+browse :: Options -> String -> IO [String]
+browse opt mdlName = withGHC $ do
+    initSession0 opt
     maybeNamesToStrings <$> lookupModuleInfo
   where
     lookupModuleInfo = findModule (mkModuleName mdlName) Nothing >>= getModuleInfo

--- a/Cabal.hs
+++ b/Cabal.hs
@@ -15,12 +15,12 @@ import Types
 
 ----------------------------------------------------------------
 
-initializeGHC :: FilePath -> [String] -> Ghc FilePath
-initializeGHC fileName options = do
+initializeGHC :: Options -> FilePath -> [String] -> Ghc FilePath
+initializeGHC opt fileName ghcOptions = do
     (owdir,mdirfile) <- getDirs
     case mdirfile of
         Nothing -> do
-            initSession options Nothing
+            initSession opt ghcOptions Nothing
             return fileName
         Just (cdir,cfile) -> do
             midirs <- parseCabalFile cfile
@@ -28,7 +28,7 @@ initializeGHC fileName options = do
             let idirs = case midirs of
                     Nothing   -> [cdir,owdir]
                     Just dirs -> dirs ++ [owdir]
-            initSession options (Just idirs)
+            initSession opt ghcOptions (Just idirs)
             return (ajustFileName fileName owdir cdir)
 
 ----------------------------------------------------------------

--- a/Check.hs
+++ b/Check.hs
@@ -18,13 +18,13 @@ import Types
 ----------------------------------------------------------------
 
 checkSyntax :: Options -> String -> IO String
-checkSyntax _ file = unlines <$> check file
+checkSyntax opt file = unlines <$> check opt file
 
 ----------------------------------------------------------------
 
-check :: String -> IO [String]
-check fileName = withGHC $ do
-    file <- initializeGHC fileName options
+check :: Options -> String -> IO [String]
+check opt fileName = withGHC $ do
+    file <- initializeGHC opt fileName options
     setTargetFile file
     ref <- newRef []
     loadWithLogger (refLogger ref) LoadAllTargets `gcatch` handleParseError ref

--- a/GHCMod.hs
+++ b/GHCMod.hs
@@ -40,6 +40,8 @@ defaultOptions = Options {
     convert = toPlain
   , hlintOpts = []
   , operators = False
+  , packageConfs = []
+  , useUserPackageConf = True
   }
 
 argspec :: [OptDescr (Options -> Options)]
@@ -52,6 +54,12 @@ argspec = [ Option "l" ["tolisp"]
           , Option "o" ["operators"]
             (NoArg (\opts -> opts { operators = True }))
             "print operators, too"
+          , Option ""  ["package-conf"]
+            (ReqArg (\p opts -> opts { packageConfs = p : packageConfs opts }) "path")
+            "additional package database"
+          , Option ""  ["no-user-package-conf"]
+            (NoArg (\opts -> opts{ useUserPackageConf = False }))
+            "do not read the user package database"
           ]
 
 parseArgs :: [OptDescr (Options -> Options)] -> [String] -> (Options, [String])

--- a/List.hs
+++ b/List.hs
@@ -10,11 +10,11 @@ import UniqFM
 ----------------------------------------------------------------
 
 listModules :: Options -> IO String
-listModules opt = convert opt . nub . sort <$> list
+listModules opt = convert opt . nub . sort <$> list opt
 
-list :: IO [String]
-list = withGHC $ do
-    initSession0
+list :: Options -> IO [String]
+list opt = withGHC $ do
+    initSession0 opt
     getExposedModules <$> getSessionDynFlags
   where
     getExposedModules = map moduleNameString


### PR DESCRIPTION
The commit adds two command-line options to ghc-mod, namely
--package-conf and --no-user-package-conf.
These options work just like the similar-named GHC flags.
They are useful when working with non-standard package databases.
