### PR TITLE
add includes support to check

### DIFF
--- a/Check.hs
+++ b/Check.hs
@@ -31,7 +31,7 @@ check opt fileName = withGHC $ do
     clearWarnings
     readRef ref
   where
-    options = ["-Wall","-fno-warn-unused-do-bind"]
+    options = ["-Wall","-fno-warn-unused-do-bind"] ++ map ((++) "-i") (checkIncludes opt)
     handleParseError ref e = do
         liftIO . writeIORef ref $ errBagToStrList . srcErrorMessages $ e
         return Succeeded

--- a/GHCMod.hs
+++ b/GHCMod.hs
@@ -26,7 +26,7 @@ usage =    "ghc-mod version 0.6.0\n"
         ++ "\t ghc-mod list [-l]\n"
         ++ "\t ghc-mod lang [-l]\n"
         ++ "\t ghc-mod browse [-l] [-o] <module> [<module> ...]\n"
-        ++ "\t ghc-mod check <HaskellFile>\n"
+        ++ "\t ghc-mod check [-i inc] <HaskellFile>\n"
         ++ "\t ghc-mod type <HaskellFile> <module> <expression>\n"
         ++ "\t ghc-mod info <HaskellFile> <module> <expression>\n"
         ++ "\t ghc-mod lint [-h opt] <HaskellFile>\n"
@@ -39,6 +39,7 @@ defaultOptions :: Options
 defaultOptions = Options {
     convert = toPlain
   , hlintOpts = []
+  , checkIncludes = []
   , operators = False
   , packageConfs = []
   , useUserPackageConf = True
@@ -60,6 +61,9 @@ argspec = [ Option "l" ["tolisp"]
           , Option ""  ["no-user-package-conf"]
             (NoArg (\opts -> opts{ useUserPackageConf = False }))
             "do not read the user package database"
+          , Option "i" ["include"]
+            (ReqArg (\i opts -> opts{ checkIncludes = i : (checkIncludes opts)}) "include")
+            "directory to include in search for modules"
           ]
 
 parseArgs :: [OptDescr (Options -> Options)] -> [String] -> (Options, [String])

--- a/Types.hs
+++ b/Types.hs
@@ -11,6 +11,7 @@ import GHC.Paths (libdir)
 data Options = Options {
     convert   :: [String] -> String
   , hlintOpts :: [String]
+  , checkIncludes :: [String]
   , operators :: Bool
   , packageConfs :: [FilePath]
   , useUserPackageConf :: Bool

--- a/elisp/ghc-flymake.el
+++ b/elisp/ghc-flymake.el
@@ -16,6 +16,15 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defcustom ghc-flymake-check-includes nil
+  "list of directories to include when checking file"
+  :type '(repeat string)
+  :risky nil
+  :require 'ghc-flymake
+  :group 'ghc-flymake)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defconst ghc-error-buffer-name "*GHC Errors*")
 
 (defconst ghc-flymake-allowed-file-name-masks
@@ -44,8 +53,11 @@
    (if ghc-flymake-command
        (let ((hopts (ghc-mapconcat (lambda (x) (list "-h" x)) opts)))
 	 `(,@hopts "lint" ,file))
-     (list "check" file)))
-
+     (if (null ghc-flymake-check-includes)
+         (list "check" file)
+       (let ((includes (ghc-mapconcat (lambda (x) (list "-i" x)) ghc-flymake-check-includes)))
+         `("check" ,@includes ,file)))))
+     
 (defun ghc-flymake-toggle-command ()
   (interactive)
   (setq ghc-flymake-command (not ghc-flymake-command))


### PR DESCRIPTION
add a command-line option to ghc-mod check to allow specification of includes directories to pass through to GHC. This allows checking a file from deeper in a module hierarchy by including e.g. ../../foo or some such to allow a file to check properly. 

I've hacked in bits to ghc-flymake.el as well to allow setting this list of includes in emacs so that flymake works properly when editting these sorts of files.

this is all really hacky, so please feel free to comment accordingly :)
