### PR TITLE
Vim needs the relative path, not just the filename, to highlight errors

### DIFF
--- a/ErrMsg.hs
+++ b/ErrMsg.hs
@@ -15,7 +15,6 @@ import FastString
 import GHC
 import HscTypes
 import Outputable
-import System.FilePath
 
 #if __GLASGOW_HASKELL__ < 702
 import Pretty
@@ -64,7 +63,7 @@ ppMsg src msg
 #endif
     = file ++ ":" ++ line ++ ":" ++ col ++ ":" ++ cts ++ "\0"
   where
-    file = takeFileName $ unpackFS (srcSpanFile src)
+    file = unpackFS (srcSpanFile src)
     line = show (srcSpanStartLine src)
     col  = show (srcSpanStartCol src)
     cts  = showMsg msg


### PR DESCRIPTION
Commit 819d915aae971d85e226cb5e2300109e8102287f introduced a change which displays the filename instead of the relative path to the file in error.

I'm not a user of the Emacs side of things, so I don't know if this is required, but Vim needs relative paths in order to be able to display errors correctly.

I'm happy enough to keep rebasing this in my own repo, but it would be great if you'd consider outputting relative paths so I can use ghc-mod straight from Hackage.

No change is required for the linter as it already uses relative paths.
