### PR TITLE
fix for attoparsec-0.10

### DIFF
--- a/Cabal.hs
+++ b/Cabal.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Cabal (initializeGHC) where
 
-import Control.Applicative hiding (many)
+import Control.Applicative
 import Control.Monad
 import CoreMonad
 import Data.Attoparsec.Char8

--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -31,7 +31,7 @@ Executable ghc-mod
   Build-Depends:        base >= 4.0 && < 5, ghc, ghc-paths, transformers,
                         process, directory, filepath, old-time,
                         hlint >= 1.7.1, regex-posix,
-                        attoparsec, enumerator, attoparsec-enumerator
+                        attoparsec >= 0.10 , enumerator, attoparsec-enumerator
 Source-Repository head
   Type:                 git
   Location:             git://github.com/kazu-yamamoto/ghc-mod.git


### PR DESCRIPTION
Because of api change of attoparsec, ghc-mod cannot compile with it.
