### PR TITLE
Add support for GHC 7.4.1

### DIFF
--- a/Info.hs
+++ b/Info.hs
@@ -107,9 +107,15 @@ inModuleContext opt fileName modstr action = withGHC valid
 setContextFromTarget :: Ghc Bool
 setContextFromTarget = do
     ms <- depanal [] False
+
+#if __GLASGOW_HASKELL__ >= 704
+    top <- map (IIModule . ms_mod) <$> filterM isTop ms
+    setContext top
+#else
     top <- map ms_mod <$> filterM isTop ms
     setContext top []
-    return (top /= [])
+#endif
+    return (not . null $ top)
   where
     isTop ms = lookupMod `gcatch` returnFalse
       where


### PR DESCRIPTION
The GHC API changed a bit to accomodate the REPL changes since 7.2 (now
most top-level decls can be used in the API.) Tested and working using
virthualenv with GHC 7.0.4 and 7.2.1-rc1
