### PR TITLE
build fix for GHC 7.2

### DIFF
--- a/Flag.hs
+++ b/Flag.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Flag where
 
 import DynFlags
@@ -6,5 +8,10 @@ import Types
 listFlags :: Options -> IO String
 listFlags opt = return $ convert opt $
    [ "-f" ++ prefix ++ option
-   | (option,_,_) <- fFlags, prefix <- ["","no-"]
+#if __GLASGOW_HASKELL__ == 702
+   | (option,_,_,_) <- fFlags
+#else
+   | (option,_,_) <- fFlags
+#endif
+   , prefix <- ["","no-"]
    ]


### PR DESCRIPTION
ghc-mod 1.0.7 fails to compile with GHC 7.2.2.
In ghc-7.2, the actual type of `fFlags` is a list of 4-tuple (3-tuple in both ghc-7.0 and ghc-7.4).
