### PR TITLE
Tweak for ghc-6.12.3 compatibility

### DIFF
--- a/CabalDev.hs
+++ b/CabalDev.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DoAndIfThenElse #-}
+-- {-# LANGUAGE DoAndIfThenElse #-} -- not in GHC 6.12.3
 
 module CabalDev (modifyOptions) where
 
@@ -38,7 +38,7 @@ searchIt path = do
   a <- doesDirectoryExist (mpath path)
   if a then do
     findConf (mpath path)
-  else
+   else
     searchIt $ init path
   where
     mpath a = joinPath a </> "cabal-dev/"


### PR DESCRIPTION
Removed DoAndIfThenElse pragma in CabalDev and its use so that ghc-mod can compile under ghc-6.12.3, which lacks that flag. I've not yet been able to build ghc 7.\* for RedHat.
