### PR TITLE
Cleanup temporaries

### DIFF
--- a/GHCApi.hs
+++ b/GHCApi.hs
@@ -12,7 +12,9 @@ import Types
 ----------------------------------------------------------------
 
 withGHC :: (MonadPlus m) => Ghc (m a) -> IO (m a)
-withGHC body = ghandle ignore $ runGhc (Just libdir) body
+withGHC body = ghandle ignore $ runGhc (Just libdir) $ do
+    dflags <- getSessionDynFlags
+    defaultCleanupHandler dflags body
   where
     ignore :: (MonadPlus m) => SomeException -> IO (m a)
     ignore _ = return mzero


### PR DESCRIPTION
GHC creates temporary directories and files when GHC loads modules.
