### PR TITLE
Fixed the conflicts with the package which modify (buffer-name) value.

### DIFF
--- a/elisp/ghc-comp.el
+++ b/elisp/ghc-comp.el
@@ -270,12 +270,13 @@ unloaded modules are loaded")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun ghc-gather-import-modules-all-buffers ()
-  (let ((bufs (mapcar 'buffer-name (buffer-list)))
+  (let ((bufs (mapcar (lambda (b) (cons (buffer-name b) (buffer-file-name b)))
+		      (buffer-list)))
 	ret)
     (save-excursion
       (dolist (buf bufs (ghc-uniq-lol ret))
-	(when (string-match "\\.hs$" buf)
-	  (set-buffer buf)
+	(when (and (cdr buf) (string-match "\\.hs$" (cdr buf)))
+	  (set-buffer (car buf))
 	  (ghc-add ret (ghc-gather-import-modules-buffer)))))))
 
 (defun ghc-gather-import-modules-buffer ()

--- a/elisp/ghc-info.el
+++ b/elisp/ghc-info.el
@@ -23,7 +23,7 @@
   (let* ((expr0 (ghc-things-at-point))
 	 (expr (if ask (ghc-read-expression expr0) expr0))
 	 (cdir default-directory)
-	 (file (buffer-name))
+	 (file buffer-file-name)
 	 (buf (get-buffer-create ghc-error-buffer-name)))
     (with-current-buffer buf
       (erase-buffer)
@@ -120,7 +120,7 @@
   (let* ((ln (int-to-string (line-number-at-pos)))
 	 (cn (int-to-string (current-column)))
 	 (cdir default-directory)
-	 (file (buffer-name)))
+	 (file buffer-file-name))
     (ghc-read-lisp
      (lambda ()
        (cd cdir)


### PR DESCRIPTION
If ghc-mod is used with the package that modifies the buffer name, ghc-mod fails to guessing types.
Typically, this problem arose from the uniquify package.
