### PR TITLE
Add autoload cookie for ghc-init.

### DIFF
--- a/elisp/ghc.el
+++ b/elisp/ghc.el
@@ -61,6 +61,7 @@
 
 (defvar ghc-initialized nil)
 
+;;;###autoload
 (defun ghc-init ()
   (ghc-abbrev-init)
   (ghc-type-init)


### PR DESCRIPTION
This allows use of loaddefs.el in el-get.
