### PR TITLE
Pass options in given order

### DIFF
--- a/GHCMod.hs
+++ b/GHCMod.hs
@@ -62,7 +62,7 @@ argspec = [ Option "l" ["tolisp"]
 parseArgs :: [OptDescr (Options -> Options)] -> [String] -> (Options, [String])
 parseArgs spec argv
     = case getOpt Permute spec argv of
-        (o,n,[]  ) -> (foldl (flip id) defaultOptions o, n)
+        (o,n,[]  ) -> (foldr id defaultOptions o, n)
         (_,_,errs) -> throw (CmdArg errs)
 
 ----------------------------------------------------------------


### PR DESCRIPTION
-g and -h options should be passed in given order.

For example, `ghc-mod -g -optP-include -g -optPmacros.h check Main.hs` should pass to GHC `-optP-include -optPmacros.h`.
