### PR TITLE
fix extensions extraction from Cabal buildinfo

### DIFF
--- a/Cabal.hs
+++ b/Cabal.hs
@@ -64,7 +64,7 @@ parseCabalFile file = do
 -- SourceDirs, Extensions, and Language
 extractBuildInfo :: BuildInfo -> ([String],[Extension],Maybe Language)
 extractBuildInfo binfo = (hsSourceDirs binfo
-                         ,oldExtensions binfo
+                         ,usedExtensions binfo
                          ,defaultLanguage binfo)
 
 ----------------------------------------------------------------


### PR DESCRIPTION
When building some Cabal package with `Default-Extensions:` Header 
(for example pandoc), `ghc-mod` failed to pass proper `-X` Options.

the definition of `usedExtensions` is

```
usedExtensions bi = oldExtensions bi
                 ++ defaultExtensions bi
```
