### PR TITLE
Enable dynamic linking for FFI

### DIFF
--- a/GHCApi.hs
+++ b/GHCApi.hs
@@ -45,7 +45,7 @@ setFlags opt d idirs
     d' = d {
         packageFlags = ghcPackage : packageFlags d
       , importPaths = idirs
-      , ghcLink = NoLink
+      , ghcLink = LinkInMemory
       , hscTarget = HscInterpreted
       , flags = flags d
       }


### PR DESCRIPTION
`ghcLink` is required to be `LinkInMemory` to handle dynamic linking when `hscTarget = HscInterpreted`.
http://www.haskell.org/ghc/docs/7.4.1/html/libraries/ghc-7.4.1/GHC.html#t:HscTarget

And if .cabal file contains `Extra-libraries` field, `-l` options are automatically added.
You can also specify them manually: `ghc-mod -g -lfoo check Main.hs`.
