### PR TITLE
fly-make warning detection fix

### DIFF
--- a/Gap.hs
+++ b/Gap.hs
@@ -16,6 +16,7 @@ module Gap (
   , toStringBuffer
   , liftIO
   , extensionToString
+  , showSeverityCaption
 #if __GLASGOW_HASKELL__ >= 702
 #else
   , module Pretty
@@ -201,6 +202,14 @@ setCtx ms = do
         lookupMod = lookupModule (ms_mod_name mos) Nothing >> return True
         returnFalse = return False
 
+
+showSeverityCaption :: Severity -> String
+#if __GLASGOW_HASKELL__ >= 706
+showSeverityCaption SevWarning = "Warning:"
+showSeverityCaption _          = ""
+#else
+showSeverityCaption = const ""
+#endif
 ----------------------------------------------------------------
 -- This is Cabal, not GHC API
 


### PR DESCRIPTION
The problem is that fly-make distinguishes errors from warnings by matching the very word 'warning' at the beginning of message, and GHC 7.6 API doesn't generate such a caption explicitly, using Severity data type instead. This fix adds 'Warning:' to warning messages so fly-make can show it as a warning and not as an error. Tested with GHC 7.4.1 and GHC 7.6.1 .
