### PR TITLE
Fix Gap.extensionToString

### DIFF
--- a/Cabal.hs
+++ b/Cabal.hs
@@ -9,11 +9,11 @@ import Control.Monad
 import CoreMonad
 import Data.List
 import Distribution.PackageDescription (BuildInfo(..), usedExtensions)
+import Distribution.Text (display)
 import ErrMsg
 import GHC
 import GHCApi
 import GHCChoice
-import qualified Gap
 import System.Directory
 import System.FilePath
 import Types
@@ -33,8 +33,8 @@ initializeGHC opt fileName ghcOptions logging = withCabal ||> withoutCabal
         (owdir,cdir,cfile) <- liftIO getDirs
         cabal <- liftIO $ cabalParseFile cfile
         binfo@BuildInfo{..} <- liftIO $ cabalBuildInfo cabal
-        let exts = map (addX . Gap.extensionToString) $ usedExtensions binfo
-            lang = maybe "-XHaskell98" (addX . show) defaultLanguage
+        let exts = map (addX . display) $ usedExtensions binfo
+            lang = maybe "-XHaskell98" (addX . display) defaultLanguage
             libs = map ("-l" ++) extraLibs
             libDirs = map ("-L" ++) extraLibDirs
             gopts = ghcOptions ++ exts ++ [lang] ++ libs ++ libDirs

--- a/Gap.hs
+++ b/Gap.hs
@@ -15,7 +15,6 @@ module Gap (
   , fOptions
   , toStringBuffer
   , liftIO
-  , extensionToString
   , showSeverityCaption
 #if __GLASGOW_HASKELL__ >= 702
 #else
@@ -31,7 +30,6 @@ import ErrUtils
 import FastString
 import GHC
 import GHCChoice
-import Language.Haskell.Extension
 import Outputable
 import StringBuffer
 
@@ -209,15 +207,4 @@ showSeverityCaption SevWarning = "Warning:"
 showSeverityCaption _          = ""
 #else
 showSeverityCaption = const ""
-#endif
-----------------------------------------------------------------
--- This is Cabal, not GHC API
-
-extensionToString :: Extension -> String
-#if __GLASGOW_HASKELL__ == 704
-extensionToString (EnableExtension ext)  = show ext
-extensionToString (DisableExtension ext) = show ext -- FIXME
-extensionToString (UnknownExtension ext) = ext
-#else
-extensionToString = show
 #endif


### PR DESCRIPTION
`Gap.extensionToString` is broken in GHC 7.6.*. It converts to invalid options like "-XEnableExtension OverloadedStrings".

There is an API that converts `Extension` to `String` properly.
http://hackage.haskell.org/packages/archive/Cabal/1.16.0.3/doc/html/Distribution-Text.html
