### PR TITLE
Show types of data constructors with "browse -d"

### DIFF
--- a/Browse.hs
+++ b/Browse.hs
@@ -13,6 +13,7 @@ import TyCon
 import Type
 import Types
 import Var
+import DataCon (dataConRepType)
 
 ----------------------------------------------------------------
 
@@ -59,11 +60,15 @@ processModule minfo = mapM processName names
     inOtherModule nm = getModuleInfo (nameModule nm) >> lookupGlobalName nm
 
 showThing :: TyThing -> Maybe String
-showThing (AnId i)   = Just $ getOccString i ++ " :: " ++ showOutputable (removeForAlls $ varType i)
-showThing (ATyCon t) = unwords . toList <$> tyType t
+showThing (AnId i)     = Just $ formatType varType i
+showThing (ADataCon d) = Just $ formatType dataConRepType d
+showThing (ATyCon t)   = unwords . toList <$> tyType t
   where
     toList t' = t' : getOccString t : map getOccString (tyConTyVars t)
 showThing _          = Nothing
+
+formatType :: NamedThing a => (a -> Type) -> a -> String
+formatType f x = getOccString x ++ " :: " ++ showOutputable (removeForAlls $ f x)
 
 tyType :: TyCon -> Maybe String
 tyType typ

--- a/test/BrowseSpec.hs
+++ b/test/BrowseSpec.hs
@@ -17,3 +17,7 @@ spec = do
         it "lists up symbols with type info in the module" $ do
             syms <- lines <$> browseModule defaultOptions { detailed = True } "Data.Either"
             syms `shouldContain` "either :: (a -> c) -> (b -> c) -> Either a b -> c"
+
+        it "lists up data constructors with type info in the module" $ do
+            syms <- lines <$> browseModule defaultOptions { detailed = True} "Data.Either"
+            syms `shouldContain` "Left :: a -> Either a b"


### PR DESCRIPTION
Before:

```
% ghc-mod browse -d Data.Either
Left
Right
data Either a b
either :: (a -> c) -> (b -> c) -> Either a b -> c
lefts :: [Either a b] -> [a]
partitionEithers :: [Either a b] -> ([a], [b])
rights :: [Either a b] -> [b]
```

After:

```
% ghc-mod browse -d Data.Either
Left :: a -> Either a b
Right :: b -> Either a b
data Either a b
either :: (a -> c) -> (b -> c) -> Either a b -> c
lefts :: [Either a b] -> [a]
partitionEithers :: [Either a b] -> ([a], [b])
rights :: [Either a b] -> [b]
```
