### PR TITLE
Fixed unicode

### DIFF
--- a/Lint.hs
+++ b/Lint.hs
@@ -11,4 +11,4 @@ lintSyntax opt file = pack <$> lint opt file
     pack = unlines . map (intercalate "\0" . lines)
 
 lint :: Options -> String -> IO [String]
-lint opt file = map show <$> hlint ([file, "--quiet", "-u"] ++ hlintOpts opt)
+lint opt file = map show <$> hlint ([file, "--quiet"] ++ hlintOpts opt)


### PR DESCRIPTION
'ghc-mod browse Prelude.Unicode' or 'ghc-mod browse Control.Concurrent.Thread -d' failed with

```
ghc-mod.exe: <stdout>: commitBuffer: invalid argument (invalid character)
```

Fixed with `hSetEncoding stdout utf8`

```
> ghc-mod browse Prelude.Unicode
π
ℚ
ℤ
> ghd-mod browse Control.Concurrent.Thread -d
forkIO :: IO α -> IO (ThreadId, IO (Result α))
forkIOWithUnmask :: ((forall β. IO β -> IO β) -> IO α) -> IO (ThreadId, IO (Result α))
forkOS :: IO α -> IO (ThreadId, IO (Result α))
forkOn :: Int -> IO α -> IO (ThreadId, IO (Result α))
forkOnWithUnmask :: Int -> ((forall β. IO β -> IO β) -> IO α) -> IO (ThreadId, IO (Result α))
result :: Result α -> IO α
type Result α
```
