### PR TITLE
Testing unicode sources

### DIFF
--- a/test/InfoSpec.hs
+++ b/test/InfoSpec.hs
@@ -7,6 +7,8 @@ import Expectation
 import Info
 import Test.Hspec
 import Types
+import System.Process
+import System.Exit
 
 spec :: Spec
 spec = do
@@ -48,3 +50,7 @@ spec = do
                 cradle <- getGHCVersion >>= findCradle Nothing . fst
                 res <- infoExpr defaultOptions cradle "Main" "bar" "Main.hs"
                 res `shouldSatisfy` ("bar :: [Char]" `isPrefixOf`)
+
+        it "doesn't fail on unicode output" $ do
+            code <- rawSystem "dist/build/ghc-mod/ghc-mod" ["info", "test/data/Unicode.hs", "Unicode", "unicode"]
+            code `shouldSatisfy` (== ExitSuccess)

--- a/test/data/Unicode.hs
+++ b/test/data/Unicode.hs
@@ -1,0 +1,4 @@
+module Unicode where
+
+unicode :: α -> α
+unicode = id


### PR DESCRIPTION
We can't test using `infoExpr` because there is error only on output. I don't know if it's right way to call `rawSystem` and check its exit code, but it works (fails when I remove `hSetEncoding stdout utf8` in GHCMod.hs's main).
