### PR TITLE
Fix package name in ghc-pkg.el

### DIFF
--- a/elisp/ghc-pkg.el
+++ b/elisp/ghc-pkg.el
@@ -1,5 +1,5 @@
 (define-package
-  "ghc-mod"
+  "ghc"
   2.0.0
   "Sub mode for Haskell mode"
   nil)


### PR DESCRIPTION
The public name of this package is "ghc", based on the package names on both Marmalade and [Melpa](http://melpa.milkbox.net/), and on the name of the `ghc-pkg.el` file. This commit fixes the contents of the `-pkg.el` file so that the name specified therein matches the external package name.
