### PR TITLE
Enable pattern matching warnings

### DIFF
--- a/Language/Haskell/GhcMod/GHCApi.hs
+++ b/Language/Haskell/GhcMod/GHCApi.hs
@@ -127,8 +127,8 @@ setFastOrNot dflags Slow = dflags {
   , hscTarget = HscInterpreted
   }
 setFastOrNot dflags Fast = dflags {
-    ghcLink   = NoLink
-  , hscTarget = HscNothing
+    ghcLink   = LinkInMemory
+  , hscTarget = HscInterpreted
   }
 
 setSlowDynFlags :: GhcMonad m => m ()

--- a/test/CheckSpec.hs
+++ b/test/CheckSpec.hs
@@ -35,3 +35,9 @@ spec = do
                 cradle <- getGHCVersion >>= findCradle Nothing . fst
                 res <- checkSyntax defaultOptions cradle ["Baz.hs"]
                 res `shouldSatisfy` ("Baz.hs:5:1:Warning:" `isPrefixOf`)
+
+        it "can check pattern matching warnings" $ do
+            withDirectory_ "test/data" $ do
+                cradle <- getGHCVersion >>= findCradle Nothing . fst
+                res <- checkSyntax defaultOptions cradle ["Pattern.hs"]
+                res `shouldSatisfy` ("Pattern.hs:3:1:Warning: Pattern match(es) are non-exhaustive" `isPrefixOf`)

--- a/test/data/Pattern.hs
+++ b/test/data/Pattern.hs
@@ -1,0 +1,8 @@
+
+myHead ::  [Int] -> Int
+myHead (x:_) = x
+
+main :: IO ()
+main = do
+    print $ myHead [1,2,3]
+


### PR DESCRIPTION
A quick fix for #144, though it negates the performance benefit of a fast path for non-TH code.  According to the [GHC module documentation](http://www.haskell.org/ghc/docs/latest/html/libraries/ghc/GHC.html#t:HscTarget), while setting HscTarget to `HscNothing` skips code generation, it also skips desugaring, which is when pattern matching warnings are detected.

GHC docs also mention that desugaring can be run standalone, which I will try implementing/benchmarking later this week.
