### PR TITLE
First pass on returning potential load targets from Cabal

### DIFF
--- a/Language/Haskell/GhcMod/Check.hs
+++ b/Language/Haskell/GhcMod/Check.hs
@@ -37,7 +37,7 @@ check _   _      []        = error "ghc-mod: check: No files given"
 check opt cradle fileNames = checkIt `gcatch` handleErrMsg ls
   where
     checkIt = do
-        readLog <- initializeFlagsWithCradle opt cradle options True
+        (readLog,_) <- initializeFlagsWithCradle opt cradle options True
         setTargetFiles fileNames
         checkSlowAndSet
         void $ load LoadAllTargets

--- a/Language/Haskell/GhcMod/Debug.hs
+++ b/Language/Haskell/GhcMod/Debug.hs
@@ -29,11 +29,11 @@ debug :: Options
       -> FilePath     -- ^ A target file.
       -> Ghc [String]
 debug opt cradle ver fileName = do
-    (gopts, incDir, pkgs) <-
+    (gopts, incDir, pkgs,_) <-
         if cabal then
-            liftIO $ fromCabalFile (ghcOpts opt) cradle ||> return (ghcOpts opt, [], [])
+            liftIO $ fromCabalFile (ghcOpts opt) cradle ||> return (ghcOpts opt, [], [], ([],[],[],[]))
           else
-            return (ghcOpts opt, [], [])
+            return (ghcOpts opt, [], [], ([],[],[],[]))
     [fast] <- do
         void $ initializeFlagsWithCradle opt cradle gopts True
         setTargetFiles [fileName]


### PR DESCRIPTION
I am not sure what is the best way to return the target information.

Returning the actual `Library`, `Executable`, `Testsuite` and `BenchMark` values causes problems in the code using it due to mismatches between the Cabal in the GHC API and the ones used in ghc-mod, so returning FilePaths seems the best option. I think this is the same problem @JPMoresmau has found in his BuildWrapper.

I think the four categories of targets should be kept separate, so the using code can decide which of them to load.

In this pull they are returned in a tuple. I would be happy to use a specific structure for it, to make it clearer. Please provide input.
