### PR TITLE
Fix `cabal install --enable-tests` in a sandbox environment

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -131,6 +131,8 @@ Test-Suite spec
                       , time
                       , transformers
                       , hspec >= 1.7.1
+  if impl(ghc < 7.6.0)
+    Build-Depends: executable-path
 
 Source-Repository head
   Type:                 git

--- a/test/InfoSpec.hs
+++ b/test/InfoSpec.hs
@@ -1,10 +1,15 @@
+{-# LANGUAGE CPP #-}
 module InfoSpec where
 
 import Control.Applicative ((<$>))
 import Data.List (isPrefixOf)
 import Language.Haskell.GhcMod
 import Language.Haskell.GhcMod.Cradle
+#ifdef VERSION_executable_path
+import System.Environment.Executable (getExecutablePath)
+#else
 import System.Environment (getExecutablePath)
+#endif
 import System.Exit
 import System.FilePath
 import System.Process


### PR DESCRIPTION
When `cabal install --enable-tests` is done in a sandbox environment, the build directory is `dist/dist-sandbox-HASH/build`.
