### PR TITLE
Take account of the absence of a corresponding value to '?\C-h' in keyboard-translate-table

### DIFF
--- a/elisp/ghc.el
+++ b/elisp/ghc.el
@@ -33,9 +33,10 @@
 ;;;
 
 (defun ghc-find-C-h ()
-  (if keyboard-translate-table
-      (aref keyboard-translate-table ?\C-h)
-    ?\C-h))
+  (or
+   (when keyboard-translate-table
+     (aref keyboard-translate-table ?\C-h))
+   ?\C-h))
 
 (defvar ghc-completion-key  "\e\t")
 (defvar ghc-document-key    "\e\C-d")


### PR DESCRIPTION
The table 'keyboard-translate-table' doesn't necessarily have a value at
the position '?\C-h'.
