### PR TITLE
Added project opt to specify module package-id

### DIFF
--- a/Language/Haskell/GhcMod/Browse.hs
+++ b/Language/Haskell/GhcMod/Browse.hs
@@ -6,6 +6,7 @@ import Data.Char
 import Data.List
 import Data.Maybe (fromMaybe)
 import DataCon (dataConRepType)
+import FastString (mkFastString)
 import GHC
 import Language.Haskell.GhcMod.Doc (showUnqualifiedPage)
 import Language.Haskell.GhcMod.GHCApi
@@ -50,7 +51,7 @@ browse opt cradle mdlName = do
     void $ initializeFlagsWithCradle opt cradle [] False
     getModule >>= getModuleInfo >>= listExports
   where
-    getModule = findModule (mkModuleName mdlName) Nothing
+    getModule = findModule (mkModuleName mdlName) (mkFastString <$> packageId opt)
     listExports Nothing       = return []
     listExports (Just mdinfo)
       | detailed opt = processModule mdinfo

--- a/Language/Haskell/GhcMod/Types.hs
+++ b/Language/Haskell/GhcMod/Types.hs
@@ -21,6 +21,8 @@ data Options = Options {
   , expandSplice  :: Bool
   -- | Line separator string.
   , lineSeparator :: LineSeparator
+  -- | Package id of module
+  , packageId :: Maybe String
   }
 
 -- | A default 'Options'.
@@ -33,6 +35,7 @@ defaultOptions = Options {
   , detailed      = False
   , expandSplice  = False
   , lineSeparator = LineSeparator "\0"
+  , packageId     = Nothing
   }
 
 ----------------------------------------------------------------

--- a/src/GHCMod.hs
+++ b/src/GHCMod.hs
@@ -27,7 +27,7 @@ usage =    "ghc-mod version " ++ showVersion version ++ "\n"
         ++ "\t ghc-mod list" ++ ghcOptHelp ++ "[-l] [-d]\n"
         ++ "\t ghc-mod lang [-l]\n"
         ++ "\t ghc-mod flag [-l]\n"
-        ++ "\t ghc-mod browse" ++ ghcOptHelp ++ "[-l] [-o] [-d] <module> [<module> ...]\n"
+        ++ "\t ghc-mod browse" ++ ghcOptHelp ++ "[-l] [-o] [-d] [-p package] <module> [<module> ...]\n"
         ++ "\t ghc-mod check" ++ ghcOptHelp ++ "<HaskellFiles...>\n"
         ++ "\t ghc-mod expand" ++ ghcOptHelp ++ "<HaskellFiles...>\n"
         ++ "\t ghc-mod debug" ++ ghcOptHelp ++ "<HaskellFile>\n"
@@ -55,6 +55,9 @@ argspec = [ Option "l" ["tolisp"]
           , Option "d" ["detailed"]
             (NoArg (\opts -> opts { detailed = True }))
             "print detailed info"
+          , Option "p" ["package"]
+            (ReqArg (\p opts -> opts { packageId = Just p, ghcOpts = ("-package " ++ p) : ghcOpts opts }) "package-id")
+            "specify package of module"
           , Option "b" ["boundary"]
             (ReqArg (\s opts -> opts { lineSeparator = LineSeparator s }) "sep")
             "specify line separator (default is Nul string)"


### PR DESCRIPTION
`ghc-mod browse Prelude -g "-package haskell98"`
fails with "Ambiguous module"
`-g "-hide-all-packages"` doesn't help

`-g "-hide-package base"` works, but you need to know about conflicted package
