### PR TITLE
Detect sandbox when no cabal file is found

### DIFF
--- a/Language/Haskell/GhcMod/GHCApi.hs
+++ b/Language/Haskell/GhcMod/GHCApi.hs
@@ -77,7 +77,8 @@ initializeFlagsWithCradle opt cradle ghcopts logging
         logger <- initSession SingleFile opt compOpts logging
         return (logger, Nothing)
       where
-        compOpts = CompilerOptions ghcopts importDirs []
+        pkgDbOpts = cradlePackageDbOpts cradle
+        compOpts = CompilerOptions (ghcopts ++ pkgDbOpts) importDirs []
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
I want to use sandbox-environment when no cabal file is found (e.g. for haskell training, trying package, ..) .

following behavior:

in executing `ghc-mod browse` or `ghc-mod list`,
- when cabal file is found, sandbox in the same dir is used.
- otherwise, sandbox which is found first in the upper dirs is used.
