### PR TITLE
Try loading a module if findModule failed for it

### DIFF
--- a/test/BrowseSpec.hs
+++ b/test/BrowseSpec.hs
@@ -2,7 +2,10 @@ module BrowseSpec where
 
 import Control.Applicative
 import Language.Haskell.GhcMod
+import Language.Haskell.GhcMod.Cradle
 import Test.Hspec
+
+import Dir
 
 spec :: Spec
 spec = do
@@ -22,3 +25,10 @@ spec = do
             cradle <- findCradle
             syms <- lines <$> browseModule defaultOptions { detailed = True} cradle "Data.Either"
             syms `shouldContain` ["Left :: a -> Either a b"]
+
+    describe "browseModule local" $ do
+        it "lists symbols in a local module" $ do
+            withDirectory_ "test/data" $ do
+                cradle <- findCradleWithoutSandbox
+                syms <- lines <$> browseModule defaultOptions cradle "Baz"
+                syms `shouldContain` ["baz"]


### PR DESCRIPTION
This is another variant of #163 with a test case and without adding an extra command-line option.
