### PR TITLE
Workaround happy travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ before_install:
 
 install:
   - cabal-1.18 update
-  - cabal-1.18 install happy
+  # work around https://github.com/simonmar/happy/issues/16
+  - if [ "$GHCVER" = '7.2.2' ]; then
+      sudo apt-get install happy;
+    else
+      cabal-1.18 install happy;
+    fi
   - export PATH=$HOME/.cabal/bin:$PATH
   - happy --version
   - cabal-1.18 install --only-dependencies --enable-tests


### PR DESCRIPTION
Use old happy to avoid build failure on travis due to the latest happy's issue.
