### PR TITLE
Pretty.showDocWith disappeard at GHC 7.7.20140110

### DIFF
--- a/Language/Haskell/GhcMod/Doc.hs
+++ b/Language/Haskell/GhcMod/Doc.hs
@@ -1,9 +1,9 @@
 module Language.Haskell.GhcMod.Doc where
 
 import DynFlags (DynFlags)
-import Language.Haskell.GhcMod.Gap (withStyle)
+import Language.Haskell.GhcMod.Gap (withStyle, showDocWith)
 import Outputable
-import Pretty
+import Pretty (Mode(..))
 
 ----------------------------------------------------------------
 
@@ -27,17 +27,17 @@ styleUnqualified = mkUserStyle neverQualify AllTheWay
 
 -- For "ghc-mod type"
 showQualifiedPage :: DynFlags -> SDoc -> String
-showQualifiedPage dflag = showDocWith PageMode . withStyle dflag styleQualified
+showQualifiedPage dflag = showDocWith dflag PageMode . withStyle dflag styleQualified
 
 -- For "ghc-mod browse" and show GHC's error messages.
 showUnqualifiedPage :: DynFlags -> SDoc -> String
-showUnqualifiedPage dflag = Pretty.showDocWith Pretty.PageMode
+showUnqualifiedPage dflag = showDocWith dflag PageMode
                           . withStyle dflag styleUnqualified
 
 -- Not used
 showQualifiedOneLine :: DynFlags -> SDoc -> String
-showQualifiedOneLine dflag = showDocWith OneLineMode . withStyle dflag styleQualified
+showQualifiedOneLine dflag = showDocWith dflag OneLineMode . withStyle dflag styleQualified
 
 -- To write Haskell code in a buffer
 showUnqualifiedOneLine :: DynFlags -> SDoc -> String
-showUnqualifiedOneLine dflag = showDocWith OneLineMode . withStyle dflag styleUnqualified
+showUnqualifiedOneLine dflag = showDocWith dflag OneLineMode . withStyle dflag styleUnqualified

--- a/Language/Haskell/GhcMod/Gap.hs
+++ b/Language/Haskell/GhcMod/Gap.hs
@@ -26,6 +26,7 @@ module Language.Haskell.GhcMod.Gap (
 #else
   , module Pretty
 #endif
+  , showDocWith
   ) where
 
 import Control.Applicative hiding (empty)
@@ -108,6 +109,15 @@ setLogAction df f =
     df { log_action = f }
 #else
     df { log_action = f df }
+#endif
+
+showDocWith :: DynFlags -> Pretty.Mode -> Pretty.Doc -> String
+#if __GLASGOW_HASKELL__ >= 707
+-- Pretty.showDocWith disappeard.
+-- https://github.com/ghc/ghc/commit/08a3536e4246e323fbcd8040e0b80001950fe9bc
+showDocWith dflags mode = Pretty.showDoc mode (pprCols dflags)
+#else
+showDocWith _ = Pretty.showDocWith
 #endif
 
 ----------------------------------------------------------------


### PR DESCRIPTION
I fixed the build for GHC 7.7.20140110 which is currently used in travis.
