### PR TITLE
Add happy dependence

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -124,6 +124,7 @@ Test-Suite spec
                       , ghc
                       , ghc-paths
                       , ghc-syb-utils
+                      , happy >= 1.17
                       , hlint >= 1.7.1
                       , io-choice
                       , old-time


### PR DESCRIPTION
Resolving dependencies...
Configuring haskell-src-exts-1.14.0.1...
Failed to install haskell-src-exts-1.14.0.1
Last 10 lines of the build log ( /Users/lingchax/.cabal/logs/haskell-src-exts-1.14.0.1.log ):
[1 of 1] Compiling Main             ( /var/folders/mb/v8h_spxs2vv_c_4fmgjg74p80000gn/T/haskell-src-exts-1.14.0.1-12611/haskell-src-exts-1.14.0.1/Setup.hs, /var/folders/mb/v8h_spxs2vv_c_4fmgjg74p80000gn/T/haskell-src-exts-1.14.0.1-12611/haskell-src-exts-1.14.0.1/dist/setup/Main.o )
Linking /var/folders/mb/v8h_spxs2vv_c_4fmgjg74p80000gn/T/haskell-src-exts-1.14.0.1-12611/haskell-src-exts-1.14.0.1/dist/setup/setup ...
Configuring haskell-src-exts-1.14.0.1...
setup: The program happy version >=1.17 is required but it could not be found.
cabal: Error: some packages failed to install:
haskell-src-exts-1.14.0.1 failed during the configure step. The exception was:
ExitFailure 1
