### PR TITLE
Suppress output of hlint

### DIFF
--- a/Language/Haskell/GhcMod/Lint.hs
+++ b/Language/Haskell/GhcMod/Lint.hs
@@ -1,9 +1,13 @@
 module Language.Haskell.GhcMod.Lint where
 
 import Control.Applicative
+import Control.Exception (finally)
 import Data.List
+import GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import Language.Haskell.GhcMod.Types
 import Language.Haskell.HLint
+import System.Directory (getTemporaryDirectory, removeFile)
+import System.IO (hClose, openTempFile, stdout)
 
 -- | Checking syntax of a target file using hlint.
 --   Warnings and errors are returned.
@@ -18,4 +22,14 @@ lintSyntax opt file = pack <$> lint opt file
 lint :: Options
      -> FilePath    -- ^ A target file.
      -> IO [String]
-lint opt file = map show <$> hlint ([file] ++ hlintOpts opt)
+lint opt file = map show <$> suppressStdout (hlint ([file] ++ hlintOpts opt))
+
+suppressStdout :: IO a -> IO a
+suppressStdout f = do
+    tmpdir <- getTemporaryDirectory
+    (path, handle) <- openTempFile tmpdir "ghc-mod-hlint"
+    removeFile path
+    dup <- hDuplicate stdout
+    hDuplicateTo handle stdout
+    hClose handle
+    f `finally` hDuplicateTo dup stdout


### PR DESCRIPTION
As you know, hlint >= 1.8.58 doesn't support `--quiet`.
Since 1ae10600e7c81b9d6cce69249ccd95c1c0cbac03, `ghc-mod lint` outputs each suggestion twice (from hlint with pretty-printed format and from ghc-mod with easy-to-parse format).

This pull-request suppresses output of hlint to restore the previous behavior.
