### PR TITLE
Fix Cabal dependency

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -75,11 +75,9 @@ Library
                       , syb
                       , time
                       , transformers
+                      , Cabal >= 1.10
   if impl(ghc < 7.7)
     Build-Depends:      convertible
-                      , Cabal >= 1.10 && < 1.17
-  else
-    Build-Depends:      Cabal >= 1.18
 
 Executable ghc-mod
   Default-Language:     Haskell2010
@@ -132,11 +130,9 @@ Test-Suite spec
                       , time
                       , transformers
                       , hspec >= 1.7.1
+                      , Cabal >= 1.10
   if impl(ghc < 7.7)
     Build-Depends:      convertible
-                      , Cabal >= 1.10 && < 1.17
-  else
-    Build-Depends:      Cabal >= 1.18
   if impl(ghc < 7.6.0)
     Build-Depends:      executable-path
 


### PR DESCRIPTION
Hi, I have removed the conditional dep on cabal since it is not
necessary, unless there is something I am missing. It works fine with
cabal 1.18 with ghc 7.4.2, 7.6.3, 7.8.1_rc2.
