### PR TITLE
display error message to minibuffer when goto next/prev error.

### DIFF
--- a/elisp/ghc-check.el
+++ b/elisp/ghc-check.el
@@ -153,7 +153,8 @@
     (if (null ovls)
 	(message "No errors or warnings")
       (progn
-        (message "%s\n" (mapconcat (lambda (x) (replace-regexp-in-string "\0" "\n" x)) errs "\n"))))
+        (message "%s\n\n%s\n" (overlay-get (car ovls) 'ghc-file)
+                 (mapconcat (lambda (x) (replace-regexp-in-string "\0" "\n" x)) errs "\n"))))
     (setq old-max-mini-window-height)))
 
 (defun ghc-check-overlay-at (p)
@@ -165,32 +166,28 @@
 (defun ghc-goto-prev-error ()
   (interactive)
   (let* ((here (point))
-	 (ovls0 (ghc-check-overlay-at here))
-	 (end (if ovls0 (overlay-start (car ovls0)) here))
-	 (ovls1 (overlays-in (point-min) end))
-	 (ovls2 (ghc-filter (lambda (ovl) (overlay-get ovl 'ghc-check)) ovls1))
-	 (pnts (mapcar 'overlay-start ovls2)))
-    (if pnts (goto-char (apply 'max pnts)))))
-
-(defun ghc-goto-and-display-prev-error ()
-  (interactive)
-  (ghc-goto-prev-error)
-  (ghc-display-errors-to-minibuf))
+         (ovls0 (ghc-check-overlay-at here))
+         (end (if ovls0 (overlay-start (car ovls0)) here))
+         (ovls1 (overlays-in (point-min) end))
+         (ovls2 (ghc-filter (lambda (ovl) (overlay-get ovl 'ghc-check)) ovls1))
+         (pnts (mapcar 'overlay-start ovls2)))
+    (if pnts (goto-char (apply 'max pnts))))
+  (cond
+   ((eq ghc-display-error 'minibuffer) (ghc-display-errors-to-minibuf))
+   ((eq ghc-display-error 'other-buffer) (ghc-display-errors))))
 
 (defun ghc-goto-next-error ()
   (interactive)
   (let* ((here (point))
-	 (ovls0 (ghc-check-overlay-at here))
-	 (beg (if ovls0 (overlay-end (car ovls0)) here))
-	 (ovls1 (overlays-in beg (point-max)))
-	 (ovls2 (ghc-filter (lambda (ovl) (overlay-get ovl 'ghc-check)) ovls1))
-	 (pnts (mapcar 'overlay-start ovls2)))
-    (if pnts (goto-char (apply 'min pnts)))))
-
-(defun ghc-goto-and-display-next-error ()
-  (interactive)
-  (ghc-goto-next-error)
-  (ghc-display-errors-to-minibuf))
+         (ovls0 (ghc-check-overlay-at here))
+         (beg (if ovls0 (overlay-end (car ovls0)) here))
+         (ovls1 (overlays-in beg (point-max)))
+         (ovls2 (ghc-filter (lambda (ovl) (overlay-get ovl 'ghc-check)) ovls1))
+         (pnts (mapcar 'overlay-start ovls2)))
+    (if pnts (goto-char (apply 'min pnts))))
+  (cond
+   ((eq ghc-display-error 'minibuffer) (ghc-display-errors-to-minibuf))
+   ((eq ghc-display-error 'other-buffer) (ghc-display-errors))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/elisp/ghc.el
+++ b/elisp/ghc.el
@@ -9,10 +9,12 @@
 ;; (autoload 'ghc-init "ghc" nil t)
 ;; (add-hook 'haskell-mode-hook (lambda () (ghc-init)))
 ;;
-;; Or you wish to display error to minibuffer.
+;; Or if you wish to display error each goto next/prev error,
+;; set ghc-display-error valiable.
 ;;
 ;; (autoload 'ghc-init "ghc" nil t)
-;; (setq ghc-display-error-to-minibuffer t)
+;; (setq ghc-display-error 'minibuffer) ; to minibuffer
+;; ; (setq ghc-display-error 'other-buffer) ; to other-buffer
 ;; (add-hook 'haskell-mode-hook (lambda () (ghc-init)))
 
 ;;
@@ -64,7 +66,7 @@
 (defvar ghc-shallower-key   "\C-c<")
 (defvar ghc-deeper-key      "\C-c>")
 
-(defvar ghc-display-error-to-minibuffer  nil)
+(defvar ghc-display-error   nil)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -84,13 +86,8 @@
     (define-key haskell-mode-map ghc-info-key        'ghc-show-info)
     (define-key haskell-mode-map ghc-expand-key      'ghc-expand-th)
     (define-key haskell-mode-map ghc-import-key      'ghc-import-module)
-    (if ghc-display-error-to-minibuffer
-        (progn
-          (define-key haskell-mode-map ghc-previous-key    'ghc-goto-and-display-prev-error)
-          (define-key haskell-mode-map ghc-next-key        'ghc-goto-and-display-next-error))
-      (progn
-        (define-key haskell-mode-map ghc-previous-key    'ghc-goto-prev-error)
-        (define-key haskell-mode-map ghc-next-key        'ghc-goto-next-error)))
+    (define-key haskell-mode-map ghc-previous-key    'ghc-goto-prev-error)
+    (define-key haskell-mode-map ghc-next-key        'ghc-goto-next-error)
     (define-key haskell-mode-map ghc-help-key        'ghc-display-errors)
     (define-key haskell-mode-map ghc-insert-key      'ghc-insert-template)
     (define-key haskell-mode-map ghc-sort-key        'ghc-sort-lines)


### PR DESCRIPTION
When goto-next/prev-error, this PR automatically display error massage in the current line to minibuffer.
Enable us to check the message immediately without open new buffer by M-?.
ghc-init with ghc-display-error-to-minibuffer activate this feature.
