### PR TITLE
fix filepath handling in windows

### DIFF
--- a/elisp/ghc-check.el
+++ b/elisp/ghc-check.el
@@ -66,7 +66,7 @@
   (let ((regex "^\\([^\n\0]*\\):\\([0-9]+\\):\\([0-9]+\\): *\\(.+\\)")
 	info infos)
     (while (re-search-forward regex nil t)
-      (let* ((file (match-string 1))
+      (let* ((file (expand-file-name (match-string 1)))
 	     (line (string-to-number (match-string 2)))
 	     ;; don't take column to make multiple same errors to a single.
 	     (msg  (match-string 4))


### PR DESCRIPTION
on windows,
ghc-check.el line 114: 

```
(string= ofile file)
```

is always false because "ofile" is posix-filepath format and "file" is windows format.
expand-file-name converts filepath to posix-format.
