### PR TITLE
Use temporary buffer for `ghc-display`

### DIFF
--- a/elisp/ghc-check.el
+++ b/elisp/ghc-check.el
@@ -144,7 +144,8 @@
        nil
        (lambda ()
 	 (insert (overlay-get (car ovls) 'ghc-file) "\n\n")
-	 (mapc (lambda (x) (insert x "\n\n")) errs))))))
+	 (mapc (lambda (x) (insert x "\n\n")) errs)))
+	 (ghc-focus-display))))
 
 (defun ghc-display-errors-to-minibuf ()
   (interactive)

--- a/elisp/ghc-func.el
+++ b/elisp/ghc-func.el
@@ -161,6 +161,10 @@
       (display-buffer buf))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defun ghc-focus-display ()
+  (pop-to-buffer ghc-error-buffer-name))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun ghc-run-ghc-mod (cmds)
   (ghc-executable-find ghc-module-command


### PR DESCRIPTION
Instead of opening a normal editable buffer (in which editing text does
not make a lot of sense), use Emacs's temporary buffer. Benefits:
- Read only: Text cannot be modified when focused.
- Much easier to close (press q), after reading or copying from the
   warning/error.

Includes another minor change i.e. automatic focus on the error buffer after display.
