### PR TITLE
added -g option to ghc-modi

### DIFF
--- a/src/GHCModi.hs
+++ b/src/GHCModi.hs
@@ -61,12 +61,15 @@ argspec :: [OptDescr (Options -> Options)]
 argspec = [ Option "b" ["boundary"]
             (ReqArg (\s opts -> opts { lineSeparator = LineSeparator s }) "sep")
             "specify line separator (default is Nul string)"
+          , Option "g" []
+            (ReqArg (\s opts -> opts { ghcOpts = s : ghcOpts opts }) "flag") "specify a ghc flag"
           ]
 
 usage :: String
 usage =    "ghc-modi version " ++ showVersion version ++ "\n"
         ++ "Usage:\n"
         ++ "\t ghc-modi [-b sep]\n"
+        ++ "\t ghc-modi [-g flag]\n"
         ++ "\t ghc-modi help\n"
 
 parseArgs :: [OptDescr (Options -> Options)] -> [String] -> (Options, [String])


### PR DESCRIPTION
Added a -g flag to ghc-modi similar to the one in ghc-mod. This is needed for example if i want to use the new ghc-mod in a hsenv sandboxed project and i want ghc-modi to use the sandboxed libraries
