### PR TITLE
Fix windows tempfile handling

### DIFF
--- a/Language/Haskell/GhcMod/Lint.hs
+++ b/Language/Haskell/GhcMod/Lint.hs
@@ -31,8 +31,9 @@ suppressStdout :: IO a -> IO a
 suppressStdout f = do
     tmpdir <- getTemporaryDirectory
     (path, handle) <- openTempFile tmpdir "ghc-mod-hlint"
-    removeFile path
     dup <- hDuplicate stdout
     hDuplicateTo handle stdout
     hClose handle
-    f `finally` hDuplicateTo dup stdout
+    f `finally` do
+        hDuplicateTo dup stdout
+        removeFile path


### PR DESCRIPTION
On Windows, `ghc-mod lint` fails with following message.

```
ghc-mod: DeleteFile "<Ommit>\\Temp\\ghc-mod-hlint8464": permission denied <Ommit>
```

Perhaps, On Windows, GHC opens file exclusively.
So, we move `removeFile` to `finally`.
