### PR TITLE
Check Emacs version at start

### DIFF
--- a/elisp/ghc.el
+++ b/elisp/ghc.el
@@ -20,6 +20,14 @@
 
 ;;; Code:
 
+;; defvar-local was introduced in 24.3
+(let* ((major 24)
+       (minor 3))
+  (if (or (< emacs-major-version major)
+	  (and (= emacs-major-version major)
+	       (< emacs-minor-version minor)))
+      (error "ghc-mod requires at least Emacs %d.%d" major minor)))
+
 (defconst ghc-version "4.1.0")
 
 ;; (eval-when-compile


### PR DESCRIPTION
I ran into this when I tried to use ghc-mod with Emacs 24.2, and got a mysterious error telling me that `defvar-local` was not defined.
