### PR TITLE
Bump hspec dependency, should fix #236

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -153,7 +153,7 @@ Test-Suite spec
                       , syb
                       , time
                       , transformers
-                      , hspec >= 1.7.1
+                      , hspec >= 1.8.2
   if impl(ghc < 7.7)
     Build-Depends:      convertible
                       , Cabal >= 1.10 && < 1.17


### PR DESCRIPTION
`hspec-discover --no-main` was introduced in 1.8.2
