### PR TITLE
Copy ComponentLocalBuildInfo from Cabal-1.18

### DIFF
--- a/Language/Haskell/GhcMod/Cabal18.hs
+++ b/Language/Haskell/GhcMod/Cabal18.hs
@@ -4,4 +4,23 @@ module Language.Haskell.GhcMod.Cabal18 (
   , componentPackageDeps
   ) where
 
-import Distribution.Simple.LocalBuildInfo (ComponentLocalBuildInfo(..))
+import Distribution.Package (InstalledPackageId, PackageId)
+
+data LibraryName = LibraryName String
+    deriving (Read, Show)
+
+data ComponentLocalBuildInfo
+  = LibComponentLocalBuildInfo {
+    componentPackageDeps :: [(InstalledPackageId, PackageId)],
+    componentLibraries :: [LibraryName]
+  }
+  | ExeComponentLocalBuildInfo {
+    componentPackageDeps :: [(InstalledPackageId, PackageId)]
+  }
+  | TestComponentLocalBuildInfo {
+    componentPackageDeps :: [(InstalledPackageId, PackageId)]
+  }
+  | BenchComponentLocalBuildInfo {
+    componentPackageDeps :: [(InstalledPackageId, PackageId)]
+  }
+  deriving (Read, Show)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP, ScopedTypeVariables #-}
 import Spec
 import Dir
 
@@ -22,6 +22,7 @@ main = do
   genGhcPkgCache `mapM_` pkgDirs
   system "find test -name setup-config -exec rm {} \\;"
   system "cabal --version"
+  putStrLn $ "ghc-mod was built with Cabal version " ++ VERSION_Cabal
   system "ghc --version"
 
   (putStrLn =<< debugInfo defaultOptions =<< findCradle)


### PR DESCRIPTION
This way `configDependencies` works even when the Cabal version used by
cabal-install is later than the one used by ghc-mod.
