### PR TITLE
Fix problems with GHC's Typed Holes

### DIFF
--- a/Language/Haskell/GhcMod/Gap.hs
+++ b/Language/Haskell/GhcMod/Gap.hs
@@ -15,6 +15,7 @@ module Language.Haskell.GhcMod.Gap (
   , setHideAllPackages
   , addPackageFlags
   , setDeferTypeErrors
+  , setWarnTypedHoles
   , setDumpSplices
   , isDumpSplices
   , filterOutChildren
@@ -257,6 +258,13 @@ setDeferTypeErrors dflag = gopt_set dflag Opt_DeferTypeErrors
 setDeferTypeErrors dflag = dopt_set dflag Opt_DeferTypeErrors
 #else
 setDeferTypeErrors = id
+#endif
+
+setWarnTypedHoles :: DynFlags -> DynFlags
+#if __GLASGOW_HASKELL__ >= 708
+setWarnTypedHoles dflag = wopt_set dflag Opt_WarnTypedHoles
+#else
+setWarnTypedHoles = id
 #endif
 
 ----------------------------------------------------------------

--- a/Language/Haskell/GhcMod/Info.hs
+++ b/Language/Haskell/GhcMod/Info.hs
@@ -22,7 +22,7 @@ import qualified GHC as G
 import GHC.SYB.Utils (Stage(TypeChecker), everythingStaged)
 import Language.Haskell.GhcMod.Doc (showPage, showOneLine, getStyle)
 import Language.Haskell.GhcMod.GHCApi
-import Language.Haskell.GhcMod.Gap (HasType(..), setDeferTypeErrors)
+import Language.Haskell.GhcMod.Gap (HasType(..), setWarnTypedHoles, setDeferTypeErrors)
 import qualified Language.Haskell.GhcMod.Gap as Gap
 import Language.Haskell.GhcMod.Types
 import Language.Haskell.GhcMod.Convert
@@ -130,7 +130,7 @@ pretty dflag style = showOneLine dflag style . Gap.typeForUser
 
 inModuleContext :: FilePath -> (DynFlags -> PprStyle -> Ghc a) -> Ghc a
 inModuleContext file action =
-    withDynFlags (setDeferTypeErrors . setNoWaringFlags) $ do
+    withDynFlags (setWarnTypedHoles . setDeferTypeErrors . setNoWaringFlags) $ do
     setTargetFiles [file]
     Gap.withContext $ do
         dflag <- G.getSessionDynFlags


### PR DESCRIPTION
Adding the `WarnTypedHoles` to the list of extensions in which `info` and `type` do their work bring back the possibility to query information about the file even if it has holes on it.
This should fix issue #268.
