### PR TITLE
Resolve a rare hang problem during initialization

### DIFF
--- a/elisp/ghc-process.el
+++ b/elisp/ghc-process.el
@@ -63,7 +63,7 @@
    (t cpro)))
 
 (defun ghc-start-process (name buf)
-  (let ((pro (start-file-process name buf ghc-interactive-command "-b" "\n" "-l")))
+  (let ((pro (start-file-process name buf ghc-interactive-command "-l" "-b" "\"\\n\"")))
     (set-process-filter pro 'ghc-process-filter)
     (set-process-sentinel pro 'ghc-process-sentinel)
     (set-process-query-on-exit-flag pro nil)


### PR DESCRIPTION
Hi Kazu,

Sometimes, though certainly not always, my Haskell buffers hang indefinitely at the "Initializing..." phase.  With the following patch, this no longer happens.  It may be that this bug is only manifested within the Nix environment that I'm using, but the change should be a harmless one for all users, and it does fix the problem for me.

Thanks,
  John
