### PR TITLE
Fix GHC 7.8.3: MatchGroup now has 4 args

### DIFF
--- a/Language/Haskell/GhcMod/Gap.hs
+++ b/Language/Haskell/GhcMod/Gap.hs
@@ -280,8 +280,10 @@ class HasType a where
 
 instance HasType (LHsBind Id) where
 #if __GLASGOW_HASKELL__ >= 708
-    getType _ (L spn FunBind{fun_matches = MG _ in_tys out_typ}) = return $ Just (spn, typ)
-      where typ = mkFunTys in_tys out_typ
+    getType _ (L spn FunBind{fun_matches = m}) = return $ Just (spn, typ)
+      where in_tys = mg_arg_tys m
+            out_typ = mg_res_ty m
+            typ = mkFunTys in_tys out_typ
 #else
     getType _ (L spn FunBind{fun_matches = MatchGroup _ typ}) = return $ Just (spn, typ)
 #endif


### PR DESCRIPTION
Rather than use a pattern match, this patch opts to explicitly extract
the fields of interest using where syntax. This keeps compatibility
across GHC 7.8 releases.

Ref: https://github.com/ghc/ghc/commit/eeaea2df3fa585db503034f419c6e4331a4d8a84#diff-259092edcc59456f526cdef255c181d1L909

Closes #285.
