### PR TITLE
interpret backslash-escaped characters at the line boundary

### DIFF
--- a/Language/Haskell/GhcMod/Convert.hs
+++ b/Language/Haskell/GhcMod/Convert.hs
@@ -39,8 +39,9 @@ class ToString a where
     toPlain :: Options -> a -> Builder
 
 lineSep :: Options -> String
-lineSep opt = lsep
+lineSep opt = interpret lsep
   where
+    interpret s = read $ "\"" ++ s ++ "\""
     LineSeparator lsep = lineSeparator opt
 
 -- |


### PR DESCRIPTION
This commit enables interpretation of backslash-escaped characters in `--boundary` (or `-b`) option.
For example, the following two commands are equivalent now:

```
ghc-mod check foo.hs | perl -plE 's/\0/\n  /g'
```

```
ghc-mod check -b "\n  " foo.hs
```
