### PR TITLE
Remove `toGhcModT` it's not needed anymore.

### DIFF
--- a/Language/Haskell/GhcMod/Internal.hs
+++ b/Language/Haskell/GhcMod/Internal.hs
@@ -36,8 +36,6 @@ module Language.Haskell.GhcMod.Internal (
   -- * Monad utilities
   , runGhcModT'
   , withErrorHandler
-  -- ** Conversion
-  , toGhcModT
   -- ** Accessing 'GhcModEnv' and 'GhcModState'
   , options
   , cradle

--- a/Language/Haskell/GhcMod/Logger.hs
+++ b/Language/Haskell/GhcMod/Logger.hs
@@ -125,7 +125,7 @@ withLoggerTwice setDF1 body1 setDF2 body2 = do
             Right <$> readAndClearLogBagRef logref
   -- Merge errors and warnings
   dflags <- G.getSessionDynFlags
-  style <- toGhcModT getStyle
+  style <- getStyle
   case (err1, err2) of
     (Right b1, Right b2) -> do let (warn1,warn2) = mergeErrors dflags style b1 b2
                                errAndWarnBagToStr Right emptyBag (warn1 `unionBags` b2)
@@ -150,7 +150,7 @@ errBagToStr = errBagToStr' Left
 errBagToStr' :: IOish m => (String -> a) -> Bag ErrMsg -> GhcModT m a
 errBagToStr' f err = do
     dflags <- G.getSessionDynFlags
-    style <- toGhcModT getStyle
+    style <- getStyle
     ret <- convert' (errBagToStrList dflags style err)
     return $ f ret
 

--- a/Language/Haskell/GhcMod/Monad.hs
+++ b/Language/Haskell/GhcMod/Monad.hs
@@ -19,8 +19,6 @@ module Language.Haskell.GhcMod.Monad (
   , runGhcModT
   , runGhcModT'
   , withErrorHandler
-  -- ** Conversion
-  , toGhcModT
   -- ** Accessing 'GhcModEnv' and 'GhcModState'
   , gmsGet
   , gmsPut
@@ -305,12 +303,6 @@ overrideGhcUserOptions action = withTempSession $ do
   initializeFlagsWithCradle opt' (gmCradle env)
 
   action ghcOpts
-
--- | This is only a transitional mechanism don't use it for new code.
-toGhcModT :: IOish m => Ghc a -> GhcModT m a
-toGhcModT a = do
-    s <- gmGhcSession <$> ask
-    liftIO $ unGhc a $ Session s
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
@serras `toGhcModT` isn't needed to run `GhcMonad m => m a` actions, `GhcModT` is an instance of `GhcMonad`.
