### PR TITLE
Try to fix each error only once

### DIFF
--- a/elisp/ghc-check.el
+++ b/elisp/ghc-check.el
@@ -367,7 +367,7 @@ nil            does not display errors/warnings.
 (defun ghc-check-insert-from-warning ()
   (interactive)
   (let ((ret t))
-    (dolist (data (mapcar (lambda (ovl) (overlay-get ovl 'ghc-msg)) (ghc-check-overlay-at (point))) ret)
+    (dolist (data (delete-dups (mapcar (lambda (ovl) (overlay-get ovl 'ghc-msg)) (ghc-check-overlay-at (point)))) ret)
       (save-excursion
 	(cond
 	 ((string-match "Inferred type: \\|no type signature:" data)


### PR DESCRIPTION
Fixes issue #334.
Now when several messages are reported on one line and the user uses `M-t`, duplicates are removed from the set of errors, so that only one fix is applied.
