### PR TITLE
Support cabal configuration flags

### DIFF
--- a/Language/Haskell/GhcMod/Debug.hs
+++ b/Language/Haskell/GhcMod/Debug.hs
@@ -31,7 +31,7 @@ debugInfo = cradle >>= \c -> convert' =<< do
     simpleCompilerOption = options >>= \op ->
         return $ CompilerOptions (ghcUserOptions op) [] []
     fromCabalFile c = options >>= \opts -> do
-        pkgDesc <- parseCabalFile $ fromJust $ cradleCabalFile c
+        pkgDesc <- parseCabalFile c $ fromJust $ cradleCabalFile c
         getCompilerOptions (ghcUserOptions opts) c pkgDesc
 
 ----------------------------------------------------------------

--- a/Language/Haskell/GhcMod/Error.hs
+++ b/Language/Haskell/GhcMod/Error.hs
@@ -18,6 +18,8 @@ data GhcModError = GMENoMsg
                  -- 'fail' calls on GhcModT.
                  | GMECabalConfigure GhcModError
                  -- ^ Configuring a cabal project failed.
+                 | GMECabalFlags GhcModError
+                 -- ^ Retrieval of the cabal configuration flags failed.
                  | GMEProcess [String] GhcModError
                  -- ^ Launching an operating system process failed. The first
                  -- field is the command.

--- a/Language/Haskell/GhcMod/Monad.hs
+++ b/Language/Haskell/GhcMod/Monad.hs
@@ -204,7 +204,7 @@ initializeFlagsWithCradle opt c
     cabal = isJust mCradleFile
     ghcopts = ghcUserOptions opt
     withCabal = do
-        pkgDesc <- parseCabalFile $ fromJust mCradleFile
+        pkgDesc <- parseCabalFile c $ fromJust mCradleFile
         compOpts <- getCompilerOptions ghcopts c pkgDesc
         initSession CabalPkg opt compOpts
     withSandbox = initSession SingleFile opt compOpts

--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -34,6 +34,7 @@ Extra-Source-Files:     ChangeLog
                         test/data/broken-cabal/cabal.sandbox.config.in
                         test/data/broken-sandbox/*.cabal
                         test/data/broken-sandbox/cabal.sandbox.config
+                        test/data/cabal-flags/*.cabal
                         test/data/check-test-subdir/*.cabal
                         test/data/check-test-subdir/src/Check/Test/*.hs
                         test/data/check-test-subdir/test/*.hs

--- a/src/GHCMod.hs
+++ b/src/GHCMod.hs
@@ -149,6 +149,8 @@ main = flip E.catches handlers $ do
           hPutStrLn stderr msg
       Left (GMECabalConfigure msg) ->
           hPutStrLn stderr $ "cabal configure failed: " ++ show msg
+      Left (GMECabalFlags msg) ->
+          hPutStrLn stderr $ "retrieval of the cabal configuration flags failed: " ++ show msg
       Left (GMEProcess cmd msg) ->
           hPutStrLn stderr $
             "launching operating system process `"++c++"` failed: " ++ show msg

--- a/test/data/cabal-flags/cabal-flags.cabal
+++ b/test/data/cabal-flags/cabal-flags.cabal
@@ -1,0 +1,14 @@
+name: cabal-flags
+version: 0.1.0
+build-type: Simple
+cabal-version: >= 1.8
+
+flag test-flag
+  default: False
+
+library
+  build-depends: base == 4.*
+
+  if flag(test-flag)
+    build-depends: Cabal >= 1.10
+


### PR DESCRIPTION
Currently, ghc-mod uses a project's default configuration flags for finalizing the `PackageDescription`. This means that if you're working on code that is only intended to be compiled with a non-default flag assignment, `ghc-mod check` will not actually check it. 

I've made the necessary changes such that `ghc-mod` will use the flag assignments from the local build info. This does change the signature of `parseCabalFile` slightly, becoming slightly less general, but it doesn't seem to break anything. 
