### PR TITLE
watch cabal file - fixes #378

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -160,6 +160,7 @@ Executable ghc-modi
                       , split
                       , ghc
                       , ghc-mod
+                      , time
 
 Test-Suite doctest
   Type:                 exitcode-stdio-1.0


### PR DESCRIPTION
This is not for merging, just discussion - in practice, it still fails until cabal install --only-dependencies; cabal build has been run in the directory. is there a better way to check for staleness?
