### PR TITLE
recover test for GHC >= 706

### DIFF
--- a/Language/Haskell/GhcMod/Utils.hs
+++ b/Language/Haskell/GhcMod/Utils.hs
@@ -7,10 +7,8 @@ import MonadUtils (MonadIO, liftIO)
 import System.Directory (getCurrentDirectory, setCurrentDirectory)
 import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
-#ifndef SPEC
 import System.Environment
 import System.FilePath ((</>), takeDirectory)
-#endif
 
 -- dropWhileEnd is not provided prior to base 4.5.0.0.
 dropWhileEnd :: (a -> Bool) -> [a] -> [a]


### PR DESCRIPTION
If we [code]--enable-tests[/code] and have a GHC >= 706 the function [code]getExecutablePath'[/code] doesn't have the necessary imports. I didn't find a reason why to constraint the import based on SPEC so I removed them. I could be wrong, so I want travis-ci first report any errors.
