### PR TITLE
recover test for GHC >= 706 

### DIFF
--- a/Language/Haskell/GhcMod/Utils.hs
+++ b/Language/Haskell/GhcMod/Utils.hs
@@ -7,9 +7,10 @@ import MonadUtils (MonadIO, liftIO)
 import System.Directory (getCurrentDirectory, setCurrentDirectory)
 import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
-#ifndef SPEC
 import System.Environment
-import System.FilePath ((</>), takeDirectory)
+import System.FilePath (takeDirectory)
+#ifndef SPEC
+import System.FilePath ((</>))
 #endif
 
 -- dropWhileEnd is not provided prior to base 4.5.0.0.


### PR DESCRIPTION
If we `--enable-tests` and have a GHC >= 706 the function `getExecutablePath'` doesn't have the necessary imports. I could be wrong, so I want travis-ci first report any errors.
