### PR TITLE
Updates help info to indicate that options such as -g must be specified _after_ the command (as of version 5)

### DIFF
--- a/src/GHCMod.hs
+++ b/src/GHCMod.hs
@@ -58,7 +58,7 @@ usage :: String
 usage =
  "Usage: ghc-mod [OPTIONS...] COMMAND [OPTIONS...] \n\
  \*Global Options (OPTIONS)*\n\
- \    Global options can be specified before and after the command and\n\
+ \    Global options must be specified after the command or\n\
  \    interspersed with command specific options\n\
  \\n"
    ++ (unlines $ indent <$> optionUsage indent globalArgSpec) ++


### PR DESCRIPTION
Several ghc-mod relevant vim extensions are broken due to this change in version 5, they have relied on being able to do:

```
ghc-mod -g {ghcOpt} {command} …
```

which now gives

```
ghc-mod: unknown command: `-g'
```

the command must be `ghc-mod {command} -g {ghcOpt}`
