### PR TITLE
Remove timeout from loop in ghc-sync-process

### DIFF
--- a/elisp/ghc-process.el
+++ b/elisp/ghc-process.el
@@ -112,8 +112,9 @@
     (setq ghc-process-num-of-results (or n 1))
     (let ((pro (ghc-with-process cmd 'ghc-process-callback nil hook)))
       (condition-case nil
-	  (while (and (null ghc-process-rendezvous)
-		      (accept-process-output pro 2)))
+	  (let ((inhibit-quit nil))
+	    (while (null ghc-process-rendezvous)
+	      (accept-process-output pro)))
 	(quit
 	 (setq ghc-process-running nil))))
     ghc-process-results))


### PR DESCRIPTION
This fixes the possibility that ghc-process-running was left non-nil
after timeout.
Quit still can abort the loop.

For #405
