### PR TITLE
Limit overlays to actual position of error

### DIFF
--- a/elisp/ghc-check.el
+++ b/elisp/ghc-check.el
@@ -175,10 +175,10 @@ nil            does not display errors/warnings.
             (setq end (point)))
 	   ((string= ofile file)
 	    (forward-line (1- line))
-	    (while (eq (char-after) 32) (forward-char))
+            (forward-char (1- coln))
 	    (setq beg (point))
-	    (forward-line)
-	    (setq end (1- (point))))
+            (skip-chars-forward "^[:space:]" (line-end-position))
+	    (setq end (point)))
 	   (t
 	    (setq beg (point))
 	    (forward-line)


### PR DESCRIPTION
Currently, any errors on the same line overlap, making it impossible to skip an error and jump to the next one in the line.

Before:
![Before patch](http://imgur.com/3Bw6giE.png)

After:
![After patch](http://imgur.com/QMcg3Rl.png)

This patch fixes this by jumping to the coln given by the error and only marking the error.

![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)

Best,
Markus