### PR TITLE
Don't mark "Could not deduce" messages as warnings

### DIFF
--- a/elisp/ghc-check.el
+++ b/elisp/ghc-check.el
@@ -136,7 +136,8 @@ nil            does not display errors/warnings.
 	       (line (string-to-number (match-string 2 err)))
                (coln (string-to-number (match-string 3 err)))
 	       (msg (match-string 4 err))
-	       (wrn (string-match "^Warning" msg))
+	       (wrn (and (not (string-match "Could not deduce" msg))
+                         (string-match "^Warning" msg)))
                (hole (save-match-data
                         (when (string-match "Found hole .\\(_[_[:alnum:]]*\\)." msg)
                               (match-string 1 msg))))


### PR DESCRIPTION
IMO type errors should not be flagged as warnings.  Currently ghc-mod flags anything starting with `Warning: ` as a warning and highlights them accordingly.

This patch adds a simple check for `Could not deduce` and flags these as errors.

![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)

Best,
Markus 