### PR TITLE
create temporary directories in ghc-mod sub-directory

### DIFF
--- a/Language/Haskell/GhcMod/Utils.hs
+++ b/Language/Haskell/GhcMod/Utils.hs
@@ -69,7 +69,7 @@ uniqTempDirName dir =
 
 newTempDir :: FilePath -> IO FilePath
 newTempDir dir =
-    flip createTempDirectory (uniqTempDirName dir) =<< getTemporaryDirectory
+    flip createTempDirectory ("ghc-mod/" ++ uniqTempDirName dir) =<< getTemporaryDirectory
 
 mightExist :: FilePath -> IO (Maybe FilePath)
 mightExist f = do


### PR DESCRIPTION
ghc-mod is creating multiple temporary directories in /tmp/ for each haskell
file opened. These empty directories are not removed on exit. This patch
creates these temporary directories in ghc-mod subdirectory.
