### PR TITLE
create temporary directories in ghc-mod sub-directory

### DIFF
--- a/Language/Haskell/GhcMod/Utils.hs
+++ b/Language/Haskell/GhcMod/Utils.hs
@@ -21,12 +21,12 @@ import System.Exit (ExitCode(..))
 import System.Posix.Files (fileOwner, getFileStatus)
 import System.Posix.User (getRealUserID)
 import System.Process (readProcessWithExitCode)
-import System.FilePath (splitDrive, pathSeparators)
+import System.FilePath (splitDrive, pathSeparators, (</>))
 import System.IO.Temp (createTempDirectory)
 #ifndef SPEC
 import Control.Applicative ((<$>))
 import System.Environment
-import System.FilePath ((</>), takeDirectory)
+import System.FilePath (takeDirectory)
 #endif
 
 -- dropWhileEnd is not provided prior to base 4.5.0.0.

--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -122,6 +122,7 @@ Library
                       , haskell-src-exts
                       , text
                       , djinn-ghc >= 0.0.2.2
+                      , unix
   if impl(ghc >= 7.8)
     Build-Depends:      Cabal >= 1.18
   else
@@ -149,6 +150,7 @@ Executable ghc-mod
                       , mtl >= 2.0
                       , ghc
                       , ghc-mod
+                      , unix
 
 Executable ghc-modi
   Default-Language:     Haskell2010
@@ -172,6 +174,7 @@ Executable ghc-modi
                       , time
                       , ghc
                       , ghc-mod
+                      , unix
 
 Test-Suite doctest
   Type:                 exitcode-stdio-1.0
@@ -229,6 +232,7 @@ Test-Suite spec
                       , haskell-src-exts
                       , text
                       , djinn-ghc >= 0.0.2.2
+                      , unix
   if impl(ghc >= 7.8)
     Build-Depends:      Cabal >= 1.18
   else


### PR DESCRIPTION
ghc-mod is creating multiple temporary directories in /tmp/ for each haskell
file opened. These empty directories are not removed on exit. This patch
creates these temporary directories in ghc-mod subdirectory of the temporary
directory.