### PR TITLE
Re-add output line separator global option for expand command.

### DIFF
--- a/elisp/ghc-info.el
+++ b/elisp/ghc-info.el
@@ -127,7 +127,7 @@
 (defun ghc-expand-th ()
   (interactive)
   (let* ((file (buffer-file-name))
-	 (cmds (list "expand" file))
+	 (cmds (list "-b" "\n" "expand" file))
 	 (source (ghc-run-ghc-mod cmds)))
     (when source
       (ghc-display


### PR DESCRIPTION
https://github.com/kazu-yamamoto/ghc-mod/commit/5a4bec87559d2a6ea3db5c3ca516ab68f8c10387

Changing ArgOrder from 'Permute' into 'RequireOrder' of getOpt breaks tail-placed line separator option of 'expand' command.

https://github.com/kazu-yamamoto/ghc-mod/commit/f23b0db4df891b2481447c7828f184525f9aa435#diff-0d1fdef653b6a8da5a2ef47b199c26a9
https://github.com/kazu-yamamoto/ghc-mod/commit/dbd94c47654d75cd88ae8d60c37cf29d1bee512b#diff-0d1fdef653b6a8da5a2ef47b199c26a9

So, I propose to re-add line separator global option at begining of arguments.
This change makes 'ghc-expand-th' result to be happy!  (Default line separator is nul character!)
