### PR TITLE
Fix finding sandbox config file and directory.

### DIFF
--- a/Language/Haskell/GhcMod/Cradle.hs
+++ b/Language/Haskell/GhcMod/Cradle.hs
@@ -47,7 +47,7 @@ cabalCradle wdir = do
 sandboxCradle :: FilePath -> IO Cradle
 sandboxCradle wdir = do
     Just sbDir <- getSandboxDb wdir
-    pkgDbStack <- getPackageDbStack sbDir
+    pkgDbStack <- getPackageDbStack wdir
     tmpDir <- newTempDir sbDir
     return Cradle {
         cradleCurrentDir = wdir

--- a/Language/Haskell/GhcMod/PathsAndFiles.hs
+++ b/Language/Haskell/GhcMod/PathsAndFiles.hs
@@ -91,7 +91,9 @@ getSandboxDb :: FilePath -- ^ Path to the cabal package root directory
                          -- (containing the @cabal.sandbox.config@ file)
              -> IO (Maybe FilePath)
 getSandboxDb d = do
-  mConf <- traverse readFile =<< U.mightExist (d </> "cabal.sandbox.config")
+  mConf <- traverse readFile =<< msum <$>
+           sequence [U.mightExist (dir </> "cabal.sandbox.config")
+                    | dir <- parents d]
   return $ extractSandboxDbDir =<< mConf
 
 -- | Extract the sandbox package db directory from the cabal.sandbox.config file.


### PR DESCRIPTION
Originally in `Check.hs`:
~~~haskell
sandboxCradle :: FilePath -> IO Cradle
sandboxCradle wdir = do
Just sbDir <- getSandboxDb wdir
pkgDbStack <- getPackageDbStack sbDir
...
~~~

and in `PathsAndFiles.hs`:
~~~haskell
getPackageDbStack cdir = do
mSDir <- getSandboxDb cdir
...
~~~

the function `getSandboxDb` is applied twice and therefore cannot return the right directory.

The function `getSandboxDb` in `PathsAndFiles.hs` is modified to search in upper directories. This is required for the elisp scripts to work correctly.