### PR TITLE
Fix symbol's function definition is void: turn-off-haskell-font-lock

### DIFF
--- a/elisp/ghc-func.el
+++ b/elisp/ghc-func.el
@@ -182,9 +182,19 @@
         (funcall ins-func)
         (goto-char (point-min))
         (if (not fontify)
-            (turn-off-haskell-font-lock)
+            ;; turn-off-haskell-font-lock has been removed from haskell-mode
+            ;; test if the function is defined in our version
+            (if (fboundp 'turn-off-haskell-font-lock)
+                (turn-off-haskell-font-lock)
+              ;; it's not defined, fallback on font-lock-mode
+              (font-lock-mode -1))
           (haskell-font-lock-defaults-create)
-          (turn-on-haskell-font-lock)))
+          ;; turn-on-haskell-font-lock has been removed from haskell-mode
+          ;; test if the function is defined in our version
+          (if (fboundp 'turn-on-haskell-font-lock)
+              (turn-on-haskell-font-lock)
+            ;; it's not defined, fallback on font-lock-mode
+            (turn-on-font-lock))))
       (display-buffer buf
         '((display-buffer-reuse-window
            display-buffer-pop-up-window))))))


### PR DESCRIPTION
Hi there,

I upgraded a bunch of things (GHC, haskell-mode, ...) and I have now a problem with the Emacs mode of ghc-mod: shortcuts like *M-?* fail with the error *Symbol's function definition is void: turn-off-haskell-font-lock*.

I don't have that much knowledge of Emacs and Emacs Lisp, but checking out the recent commits of haskell-mode gave me some pointers of what could be wrong: see https://github.com/haskell/haskell-mode/commit/3b7c635c0e3180cd7b157a0d1a1df0c12ca07691

The first commit of this pull request seems to correctly fix the error in Emacs and is based on the commit I linked above.
The second commit of this pull request is only cleanup.

Regards.
