### PR TITLE
Some improvement on ghc-show-type

### DIFF
--- a/doc/emacs.piki
+++ b/doc/emacs.piki
@@ -29,7 +29,7 @@
 ?C-cC-i
 !Displays the info of this expression in another window.
 ?C-cC-t
-!Displays the type of this expression in the minibuffer. Type C-cC-t multiple time to enlarge the expression. The face of the region can be customized by "ghc-type-region" face.
+!Displays the type of this expression in the minibuffer. Type C-cC-t multiple time to enlarge the expression. The selected region can be killed or copied by C-w or M-w respectively. The type string can be copied by M-t. The face of the region can be customized by "ghc-type-region" face.
 ?C-cC-a
 !Selects one of possible cases.
 ?C-cC-f

--- a/doc/emacs.piki
+++ b/doc/emacs.piki
@@ -29,7 +29,7 @@
 ?C-cC-i
 !Displays the info of this expression in another window.
 ?C-cC-t
-!Displays the type of this expression in the minibuffer. Type C-cC-t multiple time to enlarge the expression.
+!Displays the type of this expression in the minibuffer. Type C-cC-t multiple time to enlarge the expression. The face of the region can be customized by "ghc-type-region" face.
 ?C-cC-a
 !Selects one of possible cases.
 ?C-cC-f

--- a/elisp/ghc-info.el
+++ b/elisp/ghc-info.el
@@ -31,6 +31,14 @@
 ;;; type
 ;;;
 
+(defface ghc-type-region
+  '((default :inherit region)
+    (((background light))
+     :background "LightBlue")
+    (((background dark))
+     :background "RoyalBlue"))
+  "Face used to mark region selected by `ghc-show-type'.")
+
 (defvar ghc-type-overlay nil)
 
 (make-variable-buffer-local 'ghc-type-overlay)
@@ -57,7 +65,7 @@
 
 (defun ghc-type-init ()
   (setq ghc-type-overlay (make-overlay 0 0))
-  (overlay-put ghc-type-overlay 'face 'region)
+  (overlay-put ghc-type-overlay 'face 'ghc-type-region)
   (ghc-type-clear-overlay)
   (setq after-change-functions
 	(cons 'ghc-type-clear-overlay after-change-functions))

--- a/elisp/ghc-info.el
+++ b/elisp/ghc-info.el
@@ -43,6 +43,13 @@
 
 (make-variable-buffer-local 'ghc-type-overlay)
 
+(defvar ghc-type-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-w") 'ghc-type-kill-region)
+    (define-key map (kbd "M-w") 'ghc-type-copy-region)
+    (define-key map (kbd "M-t") 'ghc-type-copy-type)
+    map))
+
 (defun ghc-type-set-ix (n)
   (overlay-put ghc-type-overlay 'ix n))
 
@@ -66,6 +73,7 @@
 (defun ghc-type-init ()
   (setq ghc-type-overlay (make-overlay 0 0))
   (overlay-put ghc-type-overlay 'face 'ghc-type-region)
+  (overlay-put ghc-type-overlay 'keymap ghc-type-map)
   (ghc-type-clear-overlay)
   (setq after-change-functions
 	(cons 'ghc-type-clear-overlay after-change-functions))
@@ -126,6 +134,25 @@
     (goto-char (point-min))
     (while (search-forward "[Char]" nil t)
       (replace-match "String"))))
+
+(defun ghc-type-copy-region ()
+  "Copy the region selected by `ghc-show-type'."
+  (interactive)
+  (kill-new (filter-buffer-substring
+             (overlay-start ghc-type-overlay) (overlay-end ghc-type-overlay)))
+  (ghc-type-clear-overlay))
+
+(defun ghc-type-kill-region ()
+  "Kill the region selected by `ghc-show-type'."
+  (interactive)
+  (kill-region (overlay-start ghc-type-overlay) (overlay-end ghc-type-overlay))
+  (ghc-type-clear-overlay))
+
+(defun ghc-type-copy-type ()
+  "Copy the current type given by `ghc-show-type'."
+  (interactive)
+  (let ((tinfo (nth (ghc-type-get-ix) (ghc-type-get-types))))
+    (kill-new (ghc-tinfo-get-info tinfo))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;


### PR DESCRIPTION
The first commit introduces new face instead of `region` face since `region` face confuses user that it is normal region (while it is not actually).

The second commit reduces this confusion to make `C-w` and `M-w` work as in normal region.
Also `M-t` copies the type string to kill ring.