### PR TITLE
add elispPath command to bootstrap elisp code from ghc-mod installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 elisp/*.elc
+elisp-bootstrap/*.elc
 *~
 /.cabal-sandbox/
 add-source-timestamps

--- a/elisp-bootstrap/Makefile
+++ b/elisp-bootstrap/Makefile
@@ -1,0 +1,30 @@
+SRCS = ghc-mod.el
+EMACS = emacs
+DETECT = xemacs
+
+TEMPFILE  = temp.el
+
+all: $(TEMPFILE) ghc-mod.el
+	$(EMACS) -batch -q -no-site-file -l ./$(TEMPFILE) -f ghc-compile
+	rm -f $(TEMPFILE)
+
+detect: $(TEMPFILE) ghc-mod.el
+	$(EMACS) -batch -q -no-site-file -l ./$(TEMPFILE) -f ghc-compile
+	rm -f $(DETECT)
+
+$(TEMPFILE):
+	@echo '(setq load-path (cons "." load-path))' >> $(TEMPFILE)
+	@echo '(defun ghc-compile () (mapcar (lambda (x) (byte-compile-file x)) (list ' >> $(TEMPFILE)
+	@echo $(SRCS)| sed -e 's/\(ghc[^ ]*\.el\)/"\1"/g' >> $(TEMPFILE)
+	@echo ')))' >> $(TEMPFILE)
+
+clean:
+	rm -f *.elc $(TEMPFILE)
+
+VERSION = `grep version ghc.el | sed -e 's/[^0-9\.]//g'`
+
+bump:
+	echo "(define-package\n  \"ghc-mod\"\n  $(VERSION)\n  \"Sub mode for Haskell mode\"\n  nil)" > ghc-pkg.el
+
+archive:
+	git archive master -o ~/ghc-$(VERSION).tar --prefix=ghc-$(VERSION)/

--- a/elisp-bootstrap/ghc-mod.el
+++ b/elisp-bootstrap/ghc-mod.el
@@ -1,0 +1,11 @@
+(defvar ghc-module-command "ghc-mod"
+"*The command name of \"ghc-mod\"")
+(defvar ghc-bootstrapped nil)
+
+(defun ghc-bootstrap ()
+  (unless ghc-bootstrapped
+    (dolist (path (process-lines ghc-module-command "elispPath"))
+      (add-to-list 'load-path path)
+      (setq ghc-bootstrapped t)))
+  (when (fboundp 'ghc-init)
+    (ghc-init)))

--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -31,6 +31,8 @@ Data-Files:             elisp/Makefile
 Data-Files:             LICENSE COPYING.BSD3 COPYING.AGPL3
 Extra-Source-Files:     ChangeLog
                         SetupCompat.hs
+                        elisp-bootstrap/Makefile
+                        elisp-bootstrap/*.el
                         NotCPP/*.hs
                         test/data/annotations/*.hs
                         test/data/broken-cabal/*.cabal

--- a/src/GHCMod.hs
+++ b/src/GHCMod.hs
@@ -15,7 +15,7 @@ import Data.Char (isSpace)
 import Exception
 import Language.Haskell.GhcMod
 import Language.Haskell.GhcMod.Internal
-import Paths_ghc_mod
+import Paths_ghc_mod (version, getDataFileName)
 import System.Console.GetOpt (OptDescr(..), ArgDescr(..), ArgOrder(..))
 import qualified System.Console.GetOpt as O
 import System.Directory (setCurrentDirectory)
@@ -185,6 +185,9 @@ usage =
  \        Debugging information related to cabal component resolution.\n\
  \\n\
  \    - boot\n\
+ \         Internal command used by the emacs frontend.\n\
+ \\n\
+ \    - elispPath\n\
  \         Internal command used by the emacs frontend.\n\
  \\n\
  \    - legacy-interactive\n\
@@ -401,6 +404,7 @@ legacyInteractiveLoop symdbreq ref world = do
         "refine" -> refineCmd args
 
         "boot"   -> bootCmd []
+        "elispPath" -> elispPathCmd []
         "browse" -> browseCmd args
 
         "quit"   -> liftIO $ exitSuccess
@@ -409,6 +413,9 @@ legacyInteractiveLoop symdbreq ref world = do
 
     liftIO $ putStr res >> putStrLn "OK" >> hFlush stdout
     legacyInteractiveLoop symdbreq ref world
+
+elispPath :: IOish m => GhcModT m String
+elispPath = liftIO $ getDataFileName "elisp"
 
 globalCommands :: [String] -> Maybe String
 globalCommands []      = Nothing
@@ -443,6 +450,7 @@ ghcCommands (cmd:args) = do
      "doc"     -> pkgDocCmd
      "dumpsym" -> dumpSymbolCmd
      "boot"    -> bootCmd
+     "elispPath" -> elispPathCmd
      "legacy-interactive" -> legacyInteractiveCmd
      _         -> fatalError $ "unknown command: `" ++ cmd ++ "'"
 
@@ -487,7 +495,7 @@ catchArgs cmd action =
 modulesCmd, languagesCmd, flagsCmd, browseCmd, checkSyntaxCmd, expandTemplateCmd,
   debugInfoCmd, componentInfoCmd, infoCmd, typesCmd, splitsCmd, sigCmd,
   refineCmd, autoCmd, findSymbolCmd, lintCmd, rootInfoCmd, pkgDocCmd,
-  dumpSymbolCmd, bootCmd, legacyInteractiveCmd
+  dumpSymbolCmd, bootCmd, legacyInteractiveCmd, elispPathCmd
   :: IOish m => [String] -> GhcModT m String
 
 modulesCmd    = withParseCmd' "modules" s $ \[] -> modules
@@ -499,6 +507,7 @@ rootInfoCmd   = withParseCmd' "root"    [] $ \[] -> rootInfo
 componentInfoCmd = withParseCmd' "debugComponent" [] $ \ts -> componentInfo ts
 -- internal
 bootCmd       = withParseCmd' "boot" [] $ \[] -> boot
+elispPathCmd  = withParseCmd' "elispPath" [] $ \[] -> elispPath
 
 dumpSymbolCmd     = withParseCmd' "dump" [] $ \[tmpdir] -> dumpSymbol tmpdir
 findSymbolCmd     = withParseCmd' "find" [] $ \[sym]  -> findSymbol sym


### PR DESCRIPTION
Per #358 this adds an elispPath command which prints out the elisp directory in the ghc-mod installation. Adds a separate elisp-bootstrap directory with elisp code to call ghc-mod with elispPath and load the real code.

I don't really know what I'm doing in elisp but this worked for me. Here's what is in my initialization for emacs:

```elisp
(add-to-list 'load-path "~/src/ghc-mod/elisp-bootstrap")
(load "ghc-mod")
(add-hook 'haskell-mode-hook (lambda () (ghc-bootstrap)))
(add-hook 'haskell-mode-hook 'turn-on-haskell-indentation)
```

Presumably you'd be able to take the elisp-boostrap dir and upload it to MELPA which would work for all future versions of ghc-mod. Possible enhancements would include better error reporting, in particular if ghc-mod isn't found then it should tell the user to install ghc-mod and ensure that it's on the PATH.