### PR TITLE
Serialize check-syntax

### DIFF
--- a/elisp/ghc-check.el
+++ b/elisp/ghc-check.el
@@ -64,9 +64,14 @@ nil            does not display errors/warnings.
 
 (defun ghc-check-syntax ()
   (interactive)
-  (ghc-with-process (ghc-check-send)
-		    'ghc-check-callback
-		    (lambda () (setq mode-line-process " -:-"))))
+  ;; Only check syntax of visible buffers
+  (when (get-buffer-window (current-buffer) t)
+    (with-timeout
+        (10 (error "ghc process may have hung or exited with an error"))
+      (while ghc-process-running (sleep-for 0.1)))
+    (ghc-with-process (ghc-check-send)
+                      'ghc-check-callback
+                      (lambda () (setq mode-line-process " -:-")))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/elisp/ghc.el
+++ b/elisp/ghc.el
@@ -117,6 +117,9 @@
     (setq ghc-initialized t)
     (defadvice save-buffer (after ghc-check-syntax-on-save activate)
       "Check syntax with GHC when a haskell-mode buffer is saved."
+      (when (eq 'haskell-mode major-mode) (ghc-check-syntax)))
+    (defadvice switch-to-buffer (after ghc-check-syntax-on-switch-to-buffer activate)
+      "Check syntax with GHC when switching to a haskell-mode buffer."
       (when (eq 'haskell-mode major-mode) (ghc-check-syntax))))
   (ghc-import-module)
   (ghc-check-syntax))


### PR DESCRIPTION
- Wait for ghc-mod to be ready before trying to check a buffer
- Times out after 10s with an error
- Only check-syntax visible buffers
- check-syntax when switching to a buffer