### PR TITLE
Typed holes

### DIFF
--- a/Language/Haskell/GhcMod/CaseSplit.hs
+++ b/Language/Haskell/GhcMod/CaseSplit.hs
@@ -47,7 +47,7 @@ splits :: IOish m
        -> Int          -- ^ Column number.
        -> GhcModT m String
 splits file lineNo colNo =
-  ghandle handler $ runGmlT' [Left file] deferErrors $ do
+  ghandle handler $ runGmlT' [Left file] deferErrorsAndHoles $ do
       opt <- options
       crdl <- cradle
       style <- getStyle

--- a/Language/Haskell/GhcMod/CaseSplit.hs
+++ b/Language/Haskell/GhcMod/CaseSplit.hs
@@ -47,7 +47,7 @@ splits :: IOish m
        -> Int          -- ^ Column number.
        -> GhcModT m String
 splits file lineNo colNo =
-  ghandle handler $ runGmlT' [Left file] deferErrorsAndHoles $ do
+  ghandle handler $ runGmlT' [Left file] deferErrors $ do
       opt <- options
       crdl <- cradle
       style <- getStyle

--- a/Language/Haskell/GhcMod/DynFlags.hs
+++ b/Language/Haskell/GhcMod/DynFlags.hs
@@ -99,8 +99,5 @@ setNoMaxRelevantBindings = id
 
 deferErrors :: DynFlags -> Ghc DynFlags
 deferErrors df = return $
-  Gap.setWarnTypedHoles $ Gap.setDeferTypeErrors $ setNoWarningFlags df
-
-deferErrorsAndHoles :: DynFlags -> Ghc DynFlags
-deferErrorsAndHoles df = return $
-  Gap.setDeferTypeErrors $ Gap.setDeferTypedHoles $ setNoWarningFlags df
+  Gap.setWarnTypedHoles $ Gap.setDeferTypedHoles $
+  Gap.setDeferTypeErrors $ setNoWarningFlags df

--- a/Language/Haskell/GhcMod/DynFlags.hs
+++ b/Language/Haskell/GhcMod/DynFlags.hs
@@ -100,3 +100,7 @@ setNoMaxRelevantBindings = id
 deferErrors :: DynFlags -> Ghc DynFlags
 deferErrors df = return $
   Gap.setWarnTypedHoles $ Gap.setDeferTypeErrors $ setNoWarningFlags df
+
+deferErrorsAndHoles :: DynFlags -> Ghc DynFlags
+deferErrorsAndHoles df = return $
+  Gap.setDeferTypeErrors $ Gap.setDeferTypedHoles $ setNoWarningFlags df

--- a/Language/Haskell/GhcMod/Gap.hs
+++ b/Language/Haskell/GhcMod/Gap.hs
@@ -14,6 +14,7 @@ module Language.Haskell.GhcMod.Gap (
   , setCabalPkg
   , setHideAllPackages
   , setDeferTypeErrors
+  , setDeferTypedHoles
   , setWarnTypedHoles
   , setDumpSplices
   , isDumpSplices
@@ -292,6 +293,13 @@ setDeferTypeErrors dflag = gopt_set dflag Opt_DeferTypeErrors
 setDeferTypeErrors dflag = dopt_set dflag Opt_DeferTypeErrors
 #else
 setDeferTypeErrors = id
+#endif
+
+setDeferTypedHoles :: DynFlags -> DynFlags
+#if __GLASGOW_HASKELL__ >= 708
+setDeferTypedHoles dflag = gopt_set dflag Opt_DeferTypedHoles
+#else
+setDeferTypedHoles = id
 #endif
 
 setWarnTypedHoles :: DynFlags -> DynFlags

--- a/Language/Haskell/GhcMod/Gap.hs
+++ b/Language/Haskell/GhcMod/Gap.hs
@@ -296,7 +296,7 @@ setDeferTypeErrors = id
 #endif
 
 setDeferTypedHoles :: DynFlags -> DynFlags
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 710
 setDeferTypedHoles dflag = gopt_set dflag Opt_DeferTypedHoles
 #else
 setDeferTypedHoles = id


### PR DESCRIPTION
There are still potentially problems [mentioned](https://github.com/kazu-yamamoto/ghc-mod/issues/438#issuecomment-120603666) by serras, but this seems like a move in the right direction.

It lets `info` and `doc` work in the presence of typed holes, whereas without this patch they fail badly.