### PR TITLE
Add Stack build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist/
 elisp/*.elc
 *~
 /.cabal-sandbox/
+/.stack-work/
 add-source-timestamps
 package.cache
 cabal.sandbox.config

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- cabal-helper-0.5.1.0
+resolver: lts-3.0


### PR DESCRIPTION
With this configuration ghc-mod can be built using Stack. Tested on Windows 7 64-bit using MinGHC, which is easy to install (`minghc-7.10.2-x86_64.exe` from https://github.com/fpco/minghc/releases/tag/2015-08-13).

Trying to build with Cabal (in a sandbox) fails due to a `cabal-helper` dependency resolution problem.