### PR TITLE
Rearrange loadTargets code.

### DIFF
--- a/Language/Haskell/GhcMod/Internal.hs
+++ b/Language/Haskell/GhcMod/Internal.hs
@@ -40,6 +40,7 @@ module Language.Haskell.GhcMod.Internal (
   , cradle
   , getCompilerMode
   , setCompilerMode
+  , targetGhcOptions
   , withOptions
   -- * 'GhcModError'
   , gmeDoc


### PR DESCRIPTION
The loadTargets function is exposed via the Internal module for use by
external programmes, such as HaRe.

Re-arrange to code so that it can still be called with a list of string
targets, as it was before.

The passing in of `opts` can be avoided if `loadTargets` moves to the `GhcModT` monad