### PR TITLE
Use https in Location url to get clickable link on hackage web page

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -251,4 +251,4 @@ Test-Suite spec
 
 Source-Repository head
   Type:                 git
-  Location:             git://github.com/kazu-yamamoto/ghc-mod.git
+  Location:             https://github.com/kazu-yamamoto/ghc-mod.git


### PR DESCRIPTION
If you view the hackage project page at https://hackage.haskell.org/package/ghc-mod in a browser, the link at **Source repository** cannot be followed because browsers don't recognize the git protocol. This is fixed by using https.